### PR TITLE
[#10] fix : gradle caching을 통한 발드 속도 향상 및 테스트 후 결과를 볼수있게 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,30 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Test with Gradle
         run: ./gradlew --info test
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: ${{ always() }}  # 테스트가 실패하여도 Report를 보기 위해 `always`로 설정
+        with:
+         files: build/test-results/**/*.xml
+
+      - name: Cleanup Gradle Cache
+        if: ${{ always() }}
+        run: |
+         rm -f ~/.gradle/caches/modules-2/modules-2.lock
+         rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
## 개요
caching을 통한 발드 속도 향상
테스트 후 결과를 볼수있게 수정

## 작업사항
- actions/cache 추가
- EnricoMi/publish-unit-test-result-action 추가

## 관련 이슈
- #10
