### PR TITLE
상품 목록 조회 시 id도 함께 반환하도록 수정 

### DIFF
--- a/src/main/java/bc1/gream/domain/product/dto/response/ProductQueryResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/ProductQueryResponseDto.java
@@ -1,6 +1,7 @@
 package bc1.gream.domain.product.dto.response;
 
 public record ProductQueryResponseDto(
+    Long id,
     String brand,
     String name,
     String imageUrl,


### PR DESCRIPTION
## 개요
상품 목록 조회 시 id 필드가 없어서 단일 조회를 하지 못하여 id 필드 추가해줌 

## 작업사항
- 상품 목록 조회 응답 DTO 에 id 필드 추가 

## 관련 이슈
- close #75 
