### PR TITLE
Sell 중간레이어 Transactional을 제거

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/service/BuyService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/BuyService.java
@@ -158,11 +158,13 @@ public class BuyService {
      * @param price     구매를 원하는 상품 가격
      * @return 구매입찰
      */
+    @Transactional(readOnly = true)
     public Buy getRecentBuyBidOf(Long productId, Long price) {
         return buyRepository.findByProductIdAndPrice(productId, price)
             .orElseThrow(() -> new GlobalException(BUY_BID_NOT_FOUND));
     }
 
+    @Transactional
     public void delete(Buy buy) {
         buyRepository.delete(buy);
     }

--- a/src/main/java/bc1/gream/domain/gifticon/service/GifticonService.java
+++ b/src/main/java/bc1/gream/domain/gifticon/service/GifticonService.java
@@ -5,6 +5,7 @@ import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.order.entity.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +13,7 @@ public class GifticonService {
 
     private final GifticonRepository gifticonRepository;
 
+    @Transactional
     public Gifticon saveGifticon(String gifticonUrl, Order order) {
         Gifticon gifticon = Gifticon.builder()
             .gifticonUrl(gifticonUrl)
@@ -20,6 +22,7 @@ public class GifticonService {
         return gifticonRepository.save(gifticon);
     }
 
+    @Transactional
     public void delete(Gifticon gifticon) {
         gifticonRepository.delete(gifticon);
     }

--- a/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
+++ b/src/main/java/bc1/gream/domain/order/service/command/OrderCommandService.java
@@ -25,6 +25,7 @@ public class OrderCommandService {
      * @param coupon 쿠폰
      * @return 새로운 주문
      */
+    @Transactional
     public Order saveOrderOfBuy(Buy buy, User seller, Coupon coupon) {
         Long finalPrice = CouponCalculator.calculateDiscount(coupon, buy.getPrice());
         Order order = Order.builder()

--- a/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
@@ -1,27 +1,25 @@
 package bc1.gream.domain.sell.service;
 
 import bc1.gream.domain.gifticon.service.GifticonService;
+import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import bc1.gream.domain.sell.dto.response.SellBidResponseDto;
 import bc1.gream.domain.sell.dto.response.SellCancelBidResponseDto;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.mapper.SellMapper;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.sell.service.helper.deadline.Deadline;
 import bc1.gream.domain.sell.service.helper.deadline.DeadlineCalculator;
-import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SellBidService {
 
     private final SellRepository sellRepository;

--- a/src/main/java/bc1/gream/domain/sell/service/SellNowService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellNowService.java
@@ -1,23 +1,21 @@
 package bc1.gream.domain.sell.service;
 
+import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.service.BuyService;
 import bc1.gream.domain.gifticon.service.GifticonService;
-import bc1.gream.domain.sell.dto.request.SellNowRequestDto;
-import bc1.gream.domain.sell.dto.response.SellNowResponseDto;
-import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.mapper.OrderMapper;
 import bc1.gream.domain.order.service.command.OrderCommandService;
+import bc1.gream.domain.sell.dto.request.SellNowRequestDto;
+import bc1.gream.domain.sell.dto.response.SellNowResponseDto;
 import bc1.gream.domain.user.coupon.entity.Coupon;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.service.CouponService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SellNowService {
 
     private final BuyService buyService;

--- a/src/main/java/bc1/gream/domain/sell/service/SellService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellService.java
@@ -2,9 +2,9 @@ package bc1.gream.domain.sell.service;
 
 import static bc1.gream.global.common.ResultCase.SELL_BID_PRODUCT_NOT_FOUND;
 
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
-import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +47,7 @@ public class SellService {
      * @param seller 판매입찰자
      * @return 삭제된 판매입찰
      */
+    @Transactional
     public Sell deleteSellByIdAndUser(Long sellId, User seller) {
         Sell sell = findByIdAndUser(sellId, seller);
         sellRepository.delete(sell);

--- a/src/main/java/bc1/gream/domain/user/service/CouponService.java
+++ b/src/main/java/bc1/gream/domain/user/service/CouponService.java
@@ -8,9 +8,9 @@ import bc1.gream.domain.user.coupon.entity.CouponStatus;
 import bc1.gream.domain.user.coupon.repository.CouponRepository;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +25,7 @@ public class CouponService {
         coupon.changeStatus(couponStatus);
     }
 
+    @Transactional(readOnly = true)
     public Coupon findCouponById(Long couponId, User user) {
         Coupon coupon = couponRepository.findById(couponId).orElseThrow(
             () -> new GlobalException(COUPON_NOT_FOUND)


### PR DESCRIPTION
## 개요
비즈니스 로직 처리 레이어와 컨트롤러 레이어 사이의
중간레이어에서의 Transactional을 제거하였습니다.
각각의 Transaction을 통해 리소스 낭비를 최소화 하였습니다.

## 작업사항
- SellBidService Transactional 제거
- GifticonService 메소드 Transactional 추가
   - saveGifticon()
   - delete()
- SellService Transactional 추가
   - deleteSellByIdAndUser()

- BuyService Transactional 추가
   - getRecentBuyBidOf()
   - delete()
- CouponService Transactional 추가
   - findCouponById()
- OrderCommandService Transactional 추가
   - saveOrderOfBuy()

## 관련 이슈
- close #101
