### PR TITLE
반환값에 id 추가

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/controller/BuyController.java
+++ b/src/main/java/bc1/gream/domain/buy/controller/BuyController.java
@@ -5,13 +5,13 @@ import static bc1.gream.domain.user.coupon.entity.CouponStatus.ALREADY_USED;
 import static bc1.gream.domain.user.coupon.entity.CouponStatus.AVAILABLE;
 import static bc1.gream.domain.user.coupon.entity.CouponStatus.IN_USE;
 
-import bc1.gream.domain.common.facade.ChangingCouponStatusFacade;
 import bc1.gream.domain.buy.dto.request.BuyBidRequestDto;
 import bc1.gream.domain.buy.dto.request.BuyNowRequestDto;
 import bc1.gream.domain.buy.dto.response.BuyBidResponseDto;
 import bc1.gream.domain.buy.dto.response.BuyCancelBidResponseDto;
 import bc1.gream.domain.buy.dto.response.BuyNowResponseDto;
 import bc1.gream.domain.buy.service.BuyService;
+import bc1.gream.domain.common.facade.ChangingCouponStatusFacade;
 import bc1.gream.global.common.RestResponse;
 import bc1.gream.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -34,6 +34,9 @@ public class BuyController {
     private final BuyService buyService;
     private final ChangingCouponStatusFacade changingCouponStatusFacade;
 
+    /**
+     *
+     */
     @PostMapping("/{productId}")
     public RestResponse<BuyBidResponseDto> buyBidProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -45,6 +48,9 @@ public class BuyController {
         return RestResponse.success(responseDto);
     }
 
+    /**
+     *
+     */
     @DeleteMapping("/bid/{buyId}")
     public RestResponse<BuyCancelBidResponseDto> buyCancelBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -55,6 +61,9 @@ public class BuyController {
         return RestResponse.success(responseDto);
     }
 
+    /**
+     *
+     */
     @PostMapping("/{productId}/now")
     public RestResponse<BuyNowResponseDto> buyNowProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/bc1/gream/domain/buy/dto/response/BuyCancelBidResponseDto.java
+++ b/src/main/java/bc1/gream/domain/buy/dto/response/BuyCancelBidResponseDto.java
@@ -3,6 +3,8 @@ package bc1.gream.domain.buy.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
-public record BuyCancelBidResponseDto() {
+public record BuyCancelBidResponseDto(
+    Long buyId
+) {
 
 }

--- a/src/main/java/bc1/gream/domain/buy/dto/response/BuyCancelBidResponseDto.java
+++ b/src/main/java/bc1/gream/domain/buy/dto/response/BuyCancelBidResponseDto.java
@@ -1,8 +1,8 @@
 package bc1.gream.domain.buy.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
 
-@JsonIgnoreProperties
+@Builder
 public record BuyCancelBidResponseDto(
     Long buyId
 ) {

--- a/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
+++ b/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
@@ -17,8 +17,9 @@ public interface BuyMapper {
     @Mapping(source = "id", target = "buyId")
     BuyBidResponseDto toBuyBidResponseDto(Buy buy);
 
-    @Mapping(target = "price", source = "price")
-    @Mapping(target = "tradeDate", source = "createdAt")
+    @Mapping(source = "price", target = "price")
+    @Mapping(source = "createdAt", target = "tradeDate")
+    @Mapping(source = "id", target = "id")
     TradeResponseDto toTradeResponseDto(Buy buy);
 
     @Mapping(source = "id", target = "orderId")

--- a/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
+++ b/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
@@ -19,7 +19,6 @@ public interface BuyMapper {
 
     @Mapping(source = "price", target = "price")
     @Mapping(source = "createdAt", target = "tradeDate")
-    @Mapping(source = "id", target = "id")
     TradeResponseDto toTradeResponseDto(Buy buy);
 
     @Mapping(source = "id", target = "orderId")

--- a/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
+++ b/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
@@ -17,7 +17,6 @@ public interface BuyMapper {
     @Mapping(source = "id", target = "buyId")
     BuyBidResponseDto toBuyBidResponseDto(Buy buy);
 
-    @Mapping(source = "price", target = "price")
     @Mapping(source = "createdAt", target = "tradeDate")
     TradeResponseDto toTradeResponseDto(Buy buy);
 

--- a/src/main/java/bc1/gream/domain/buy/service/BuyService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/BuyService.java
@@ -80,7 +80,7 @@ public class BuyService {
 
         buyRepository.delete(buyBid);
 
-        return new BuyCancelBidResponseDto();
+        return new BuyCancelBidResponseDto(buyId);
     }
 
     public BuyNowResponseDto buyNowProduct(User user, BuyNowRequestDto requestDto, Long productId) {

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 읽기 전용
- **/
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/products")
@@ -40,7 +40,7 @@ public class ProductQueryController {
 
     /**
      * 상품 전체 조회
-     **/
+     */
     @GetMapping
     public RestResponse<List<ProductQueryResponseDto>> findAll() {
         List<Product> products = productService.findAll();
@@ -52,7 +52,7 @@ public class ProductQueryController {
 
     /**
      * 상품 상세조회
-     **/
+     */
     @GetMapping("/{id}")
     public RestResponse<ProductQueryResponseDto> findAllBy(
         @PathVariable("id") Long productId
@@ -64,7 +64,7 @@ public class ProductQueryController {
 
     /**
      * 상품 체결내역 조회
-     **/
+     */
     @GetMapping("/{id}/trade")
     public RestResponse<List<TradeResponseDto>> findAllTrades(
         @PathVariable("id") Long productId
@@ -78,7 +78,7 @@ public class ProductQueryController {
 
     /**
      * 판매 입찰가 조회
-     **/
+     */
     @GetMapping("/{id}/sell")
     public RestResponse<List<TradeResponseDto>> findAllSellBidPrices(
         @PathVariable("id") Long productId,
@@ -94,7 +94,7 @@ public class ProductQueryController {
 
     /**
      * 구매 입찰가 조회
-     **/
+     */
     @GetMapping("/{id}/buy")
     public RestResponse<List<TradeResponseDto>> findAllBuyBidPrices(
         @PathVariable("id") Long productId,

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -1,19 +1,19 @@
 package bc1.gream.domain.product.controller;
 
+import bc1.gream.domain.buy.entity.Buy;
+import bc1.gream.domain.buy.mapper.BuyMapper;
 import bc1.gream.domain.common.facade.BuyOrderQueryFacade;
 import bc1.gream.domain.common.facade.ProductOrderQueryFacade;
 import bc1.gream.domain.common.facade.SellOrderQueryFacade;
-import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.order.entity.Order;
-import bc1.gream.domain.sell.entity.Sell;
-import bc1.gream.domain.buy.mapper.BuyMapper;
 import bc1.gream.domain.order.mapper.OrderMapper;
-import bc1.gream.domain.sell.mapper.SellMapper;
 import bc1.gream.domain.product.dto.response.ProductQueryResponseDto;
 import bc1.gream.domain.product.dto.response.TradeResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.mapper.ProductMapper;
 import bc1.gream.domain.product.service.query.ProductService;
+import bc1.gream.domain.sell.entity.Sell;
+import bc1.gream.domain.sell.mapper.SellMapper;
 import bc1.gream.global.common.RestResponse;
 import bc1.gream.global.validator.OrderCriteriaValidator;
 import java.util.List;
@@ -36,6 +36,7 @@ public class ProductQueryController {
     private final SellOrderQueryFacade sellOrderQueryFacade;
     private final BuyOrderQueryFacade buyOrderQueryFacade;
 
+    /* 상품 전체 조회 */
     @GetMapping
     public RestResponse<List<ProductQueryResponseDto>> findAll() {
         List<Product> products = productService.findAll();
@@ -45,6 +46,7 @@ public class ProductQueryController {
         return RestResponse.success(responseDtos);
     }
 
+    /* 상품 상세조회 */
     @GetMapping("/{id}")
     public RestResponse<ProductQueryResponseDto> findAllBy(
         @PathVariable("id") Long productId
@@ -54,6 +56,7 @@ public class ProductQueryController {
         return RestResponse.success(responseDto);
     }
 
+    /* 상품 체결내역 조회 */
     @GetMapping("/{id}/trade")
     public RestResponse<List<TradeResponseDto>> findAllTrades(
         @PathVariable("id") Long productId
@@ -65,6 +68,7 @@ public class ProductQueryController {
         return RestResponse.success(tradeResponseDtos);
     }
 
+    /* 판매 입찰가 조회 */
     @GetMapping("/{id}/sell")
     public RestResponse<List<TradeResponseDto>> findAllSellBidPrices(
         @PathVariable("id") Long productId,
@@ -78,6 +82,7 @@ public class ProductQueryController {
         return RestResponse.success(tradeResponseDtos);
     }
 
+    /* 구매 입찰가 조회 */
     @GetMapping("/{id}/buy")
     public RestResponse<List<TradeResponseDto>> findAllBuyBidPrices(
         @PathVariable("id") Long productId,

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -25,7 +25,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/* 읽기 전용 */
+/**
+ * 읽기 전용
+ **/
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/products")
@@ -36,7 +38,9 @@ public class ProductQueryController {
     private final SellOrderQueryFacade sellOrderQueryFacade;
     private final BuyOrderQueryFacade buyOrderQueryFacade;
 
-    /* 상품 전체 조회 */
+    /**
+     * 상품 전체 조회
+     **/
     @GetMapping
     public RestResponse<List<ProductQueryResponseDto>> findAll() {
         List<Product> products = productService.findAll();
@@ -46,7 +50,9 @@ public class ProductQueryController {
         return RestResponse.success(responseDtos);
     }
 
-    /* 상품 상세조회 */
+    /**
+     * 상품 상세조회
+     **/
     @GetMapping("/{id}")
     public RestResponse<ProductQueryResponseDto> findAllBy(
         @PathVariable("id") Long productId
@@ -56,7 +62,9 @@ public class ProductQueryController {
         return RestResponse.success(responseDto);
     }
 
-    /* 상품 체결내역 조회 */
+    /**
+     * 상품 체결내역 조회
+     **/
     @GetMapping("/{id}/trade")
     public RestResponse<List<TradeResponseDto>> findAllTrades(
         @PathVariable("id") Long productId
@@ -68,7 +76,9 @@ public class ProductQueryController {
         return RestResponse.success(tradeResponseDtos);
     }
 
-    /* 판매 입찰가 조회 */
+    /**
+     * 판매 입찰가 조회
+     **/
     @GetMapping("/{id}/sell")
     public RestResponse<List<TradeResponseDto>> findAllSellBidPrices(
         @PathVariable("id") Long productId,
@@ -82,7 +92,9 @@ public class ProductQueryController {
         return RestResponse.success(tradeResponseDtos);
     }
 
-    /* 구매 입찰가 조회 */
+    /**
+     * 구매 입찰가 조회
+     **/
     @GetMapping("/{id}/buy")
     public RestResponse<List<TradeResponseDto>> findAllBuyBidPrices(
         @PathVariable("id") Long productId,

--- a/src/main/java/bc1/gream/domain/product/dto/response/TradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/TradeResponseDto.java
@@ -3,6 +3,7 @@ package bc1.gream.domain.product.dto.response;
 import java.time.LocalDateTime;
 
 public record TradeResponseDto(
+    Long id,
     Long price,
     LocalDateTime tradeDate
 ) {

--- a/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
+++ b/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
@@ -28,7 +28,9 @@ public class SellBidController {
     private final SellBidService sellBidService;
     private final ProductValidator productValidator;
 
-    /* 판매 입찰 생성 */
+    /**
+     * 판매 입찰 생성
+     **/
     @PostMapping("/{productId}")
     public RestResponse<SellBidResponseDto> createSellBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -40,7 +42,9 @@ public class SellBidController {
         return RestResponse.success(responseDto);
     }
 
-    /* 판매 입찰 취소 */
+    /**
+     * 판매 입찰 취소
+     **/
     @DeleteMapping("/bid/{sellId}")
     public RestResponse<SellCancelBidResponseDto> cancelSellBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
+++ b/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
@@ -1,11 +1,11 @@
 package bc1.gream.domain.sell.controller;
 
+import bc1.gream.domain.order.validator.ProductValidator;
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import bc1.gream.domain.sell.dto.response.SellBidResponseDto;
 import bc1.gream.domain.sell.dto.response.SellCancelBidResponseDto;
 import bc1.gream.domain.sell.service.SellBidService;
-import bc1.gream.domain.order.validator.ProductValidator;
-import bc1.gream.domain.product.entity.Product;
 import bc1.gream.global.common.RestResponse;
 import bc1.gream.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -28,6 +28,7 @@ public class SellBidController {
     private final SellBidService sellBidService;
     private final ProductValidator productValidator;
 
+    /* 판매 입찰 생성 */
     @PostMapping("/{productId}")
     public RestResponse<SellBidResponseDto> createSellBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -39,13 +40,13 @@ public class SellBidController {
         return RestResponse.success(responseDto);
     }
 
+    /* 판매 입찰 취소 */
     @DeleteMapping("/bid/{sellId}")
     public RestResponse<SellCancelBidResponseDto> cancelSellBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable Long sellId
     ) {
         SellCancelBidResponseDto responseDto = sellBidService.sellCancelBid(userDetails.getUser(), sellId);
-
         return RestResponse.success(responseDto);
     }
 }

--- a/src/main/java/bc1/gream/domain/sell/dto/response/SellCancelBidResponseDto.java
+++ b/src/main/java/bc1/gream/domain/sell/dto/response/SellCancelBidResponseDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
 public record SellCancelBidResponseDto(
-    Long id
+    Long sellId
 ) {
 
 }

--- a/src/main/java/bc1/gream/domain/sell/dto/response/SellCancelBidResponseDto.java
+++ b/src/main/java/bc1/gream/domain/sell/dto/response/SellCancelBidResponseDto.java
@@ -3,6 +3,8 @@ package bc1.gream.domain.sell.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
-public record SellCancelBidResponseDto() {
+public record SellCancelBidResponseDto(
+    Long id
+) {
 
 }

--- a/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
@@ -1,16 +1,16 @@
 package bc1.gream.domain.sell.service;
 
 import bc1.gream.domain.gifticon.service.GifticonService;
+import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import bc1.gream.domain.sell.dto.response.SellBidResponseDto;
 import bc1.gream.domain.sell.dto.response.SellCancelBidResponseDto;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.mapper.SellMapper;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.sell.service.helper.deadline.Deadline;
 import bc1.gream.domain.sell.service.helper.deadline.DeadlineCalculator;
-import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -55,6 +55,6 @@ public class SellBidService {
         Sell deletedSell = sellService.deleteSellByIdAndUser(sellId, seller);
         gifticonService.delete(deletedSell.getGifticon());
 
-        return new SellCancelBidResponseDto();
+        return new SellCancelBidResponseDto(deletedSell.getGifticon().getId());
     }
 }

--- a/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellBidService.java
@@ -55,6 +55,6 @@ public class SellBidService {
         Sell deletedSell = sellService.deleteSellByIdAndUser(sellId, seller);
         gifticonService.delete(deletedSell.getGifticon());
 
-        return new SellCancelBidResponseDto(deletedSell.getGifticon().getId());
+        return new SellCancelBidResponseDto(sellId);
     }
 }


### PR DESCRIPTION
## 개요
웹에서 사용할 수 있게 반환값에 id 추가.

## 작업사항
- ProductQueryController 각 메서드 별 역할 주석추가
- SellCancelBidResponseDto 에 id 추가
- sellCancelBid() 호출 시, 삭제된 기프티콘 id를 담은 SellCancelBidResponseDto 반환
- BuyCancelBidResponseDto 에 id 추가
- buyCancelBid() 호출 시, 삭제된 bid의 id를 담은 BuyCancelBidResponseDto 반환
- SellCancelBidResponseDto 에 id 추가
- sellCancelBid() 호출 시, 삭제된 bid의 id를 담은 SellCancelBidResponseDto 반환

## 관련 이슈
- clsoe #107
