### PR TITLE
각 API 별 반환 DTO 타입 변경

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/controller/BuyController.java
+++ b/src/main/java/bc1/gream/domain/buy/controller/BuyController.java
@@ -35,7 +35,7 @@ public class BuyController {
     private final ChangingCouponStatusFacade changingCouponStatusFacade;
 
     /**
-     *
+     * 구매입찰 생성
      */
     @PostMapping("/{productId}")
     public RestResponse<BuyBidResponseDto> buyBidProduct(
@@ -49,7 +49,7 @@ public class BuyController {
     }
 
     /**
-     *
+     * 구매입찰 취소
      */
     @DeleteMapping("/bid/{buyId}")
     public RestResponse<BuyCancelBidResponseDto> buyCancelBid(
@@ -62,7 +62,7 @@ public class BuyController {
     }
 
     /**
-     *
+     * 즉시구매
      */
     @PostMapping("/{productId}/now")
     public RestResponse<BuyNowResponseDto> buyNowProduct(

--- a/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
+++ b/src/main/java/bc1/gream/domain/buy/mapper/BuyMapper.java
@@ -4,7 +4,7 @@ import bc1.gream.domain.buy.dto.response.BuyBidResponseDto;
 import bc1.gream.domain.buy.dto.response.BuyNowResponseDto;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.order.entity.Order;
-import bc1.gream.domain.product.dto.response.TradeResponseDto;
+import bc1.gream.domain.product.dto.response.BuyTradeResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -17,9 +17,11 @@ public interface BuyMapper {
     @Mapping(source = "id", target = "buyId")
     BuyBidResponseDto toBuyBidResponseDto(Buy buy);
 
-    @Mapping(source = "createdAt", target = "tradeDate")
-    TradeResponseDto toTradeResponseDto(Buy buy);
-
     @Mapping(source = "id", target = "orderId")
     BuyNowResponseDto toBuyNowResponseDto(Order order);
+
+    @Mapping(source = "id", target = "buyId")
+    @Mapping(source = "price", target = "buyPrice")
+    @Mapping(source = "createdAt", target = "tradeDate")
+    BuyTradeResponseDto toBuyTradeResponseDto(Buy buy);
 }

--- a/src/main/java/bc1/gream/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/bc1/gream/domain/order/mapper/OrderMapper.java
@@ -1,9 +1,9 @@
 package bc1.gream.domain.order.mapper;
 
 import bc1.gream.domain.buy.dto.response.BuyNowResponseDto;
-import bc1.gream.domain.sell.dto.response.SellNowResponseDto;
 import bc1.gream.domain.order.entity.Order;
-import bc1.gream.domain.product.dto.response.TradeResponseDto;
+import bc1.gream.domain.product.dto.response.OrderTradeResponseDto;
+import bc1.gream.domain.sell.dto.response.SellNowResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -14,9 +14,8 @@ public interface OrderMapper {
 
     OrderMapper INSTANCE = Mappers.getMapper(OrderMapper.class);
 
-    @Mapping(target = "price", source = "finalPrice")
     @Mapping(target = "tradeDate", source = "createdAt")
-    TradeResponseDto ofTradedOrder(Order order);
+    OrderTradeResponseDto toOrderTradeResponseDto(Order order);
 
     @Mapping(source = "id", target = "orderId")
     BuyNowResponseDto toBuyNowResponseDto(Order order);

--- a/src/main/java/bc1/gream/domain/product/controller/ProductLikeController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductLikeController.java
@@ -1,6 +1,6 @@
 package bc1.gream.domain.product.controller;
 
-import bc1.gream.domain.product.dto.ProductDislikeResponseDto;
+import bc1.gream.domain.product.dto.response.ProductDislikeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductLikeResponseDto;
 import bc1.gream.domain.product.mapper.ProductMapper;
 import bc1.gream.domain.product.service.command.ProductLikeService;

--- a/src/main/java/bc1/gream/domain/product/controller/ProductLikeController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductLikeController.java
@@ -1,5 +1,6 @@
 package bc1.gream.domain.product.controller;
 
+import bc1.gream.domain.product.dto.ProductDislikeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductLikeResponseDto;
 import bc1.gream.domain.product.mapper.ProductMapper;
 import bc1.gream.domain.product.service.command.ProductLikeService;
@@ -31,12 +32,12 @@ public class ProductLikeController {
     }
 
     @DeleteMapping("/{id}/dislike")
-    public RestResponse<ProductLikeResponseDto> dislikeProduct(
+    public RestResponse<ProductDislikeResponseDto> dislikeProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable("id") Long productId
     ) {
         productLikeService.dislikeProduct(userDetails.getUser(), productId);
-        ProductLikeResponseDto responseDto = ProductMapper.INSTANCE.toLikeResponseDto("관심상품 등록 해제");
+        ProductDislikeResponseDto responseDto = ProductMapper.INSTANCE.toDislikeResponseDto("관심상품 등록 해제");
         return RestResponse.success(responseDto);
     }
 }

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -7,8 +7,10 @@ import bc1.gream.domain.common.facade.ProductOrderQueryFacade;
 import bc1.gream.domain.common.facade.SellOrderQueryFacade;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.mapper.OrderMapper;
-import bc1.gream.domain.product.dto.response.ProductQueryResponseDto;
-import bc1.gream.domain.product.dto.response.TradeResponseDto;
+import bc1.gream.domain.product.dto.response.BuyTradeResponseDto;
+import bc1.gream.domain.product.dto.response.OrderTradeResponseDto;
+import bc1.gream.domain.product.dto.response.ProductDetailsResponseDto;
+import bc1.gream.domain.product.dto.response.ProductPreviewResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.mapper.ProductMapper;
 import bc1.gream.domain.product.service.query.ProductService;
@@ -42,10 +44,10 @@ public class ProductQueryController {
      * 상품 전체 조회
      */
     @GetMapping
-    public RestResponse<List<ProductQueryResponseDto>> findAll() {
+    public RestResponse<List<ProductPreviewResponseDto>> findAll() {
         List<Product> products = productService.findAll();
-        List<ProductQueryResponseDto> responseDtos = products.stream()
-            .map(ProductMapper.INSTANCE::toQueryResponseDto)
+        List<ProductPreviewResponseDto> responseDtos = products.stream()
+            .map(ProductMapper.INSTANCE::toPreviewResponseDto)
             .toList();
         return RestResponse.success(responseDtos);
     }
@@ -54,11 +56,11 @@ public class ProductQueryController {
      * 상품 상세조회
      */
     @GetMapping("/{id}")
-    public RestResponse<ProductQueryResponseDto> findAllBy(
+    public RestResponse<ProductDetailsResponseDto> findAllBy(
         @PathVariable("id") Long productId
     ) {
         Product product = productService.findBy(productId);
-        ProductQueryResponseDto responseDto = ProductMapper.INSTANCE.toQueryResponseDto(product);
+        ProductDetailsResponseDto responseDto = ProductMapper.INSTANCE.toDetailsResponseDto(product);
         return RestResponse.success(responseDto);
     }
 
@@ -66,45 +68,45 @@ public class ProductQueryController {
      * 상품 체결내역 조회
      */
     @GetMapping("/{id}/trade")
-    public RestResponse<List<TradeResponseDto>> findAllTrades(
+    public RestResponse<List<OrderTradeResponseDto>> findAllTrades(
         @PathVariable("id") Long productId
     ) {
         List<Order> allTrades = productOrderQueryFacade.findAllTradesOf(productId);
-        List<TradeResponseDto> tradeResponseDtos = allTrades.stream()
-            .map(OrderMapper.INSTANCE::ofTradedOrder)
+        List<OrderTradeResponseDto> orderTradeResponseDtos = allTrades.stream()
+            .map(OrderMapper.INSTANCE::toOrderTradeResponseDto)
             .toList();
-        return RestResponse.success(tradeResponseDtos);
+        return RestResponse.success(orderTradeResponseDtos);
     }
 
     /**
      * 판매 입찰가 조회
      */
     @GetMapping("/{id}/sell")
-    public RestResponse<List<TradeResponseDto>> findAllSellBidPrices(
+    public RestResponse<List<SellTradeResponseDto>> findAllSellBidPrices(
         @PathVariable("id") Long productId,
         @PageableDefault(size = 5) Pageable pageable
     ) {
         OrderCriteriaValidator.validateOrderCriteria(Sell.class, pageable);
         List<Sell> allSellBids = sellOrderQueryFacade.findAllSellBidsOf(productId, pageable);
-        List<TradeResponseDto> tradeResponseDtos = allSellBids.stream()
-            .map(SellMapper.INSTANCE::toTradeResponseDto)
+        List<SellTradeResponseDto> sellTradeResponseDtos = allSellBids.stream()
+            .map(SellMapper.INSTANCE::toSellTradeResponseDto)
             .toList();
-        return RestResponse.success(tradeResponseDtos);
+        return RestResponse.success(sellTradeResponseDtos);
     }
 
     /**
      * 구매 입찰가 조회
      */
     @GetMapping("/{id}/buy")
-    public RestResponse<List<TradeResponseDto>> findAllBuyBidPrices(
+    public RestResponse<List<BuyTradeResponseDto>> findAllBuyBidPrices(
         @PathVariable("id") Long productId,
         @PageableDefault(size = 5) Pageable pageable
     ) {
         OrderCriteriaValidator.validateOrderCriteria(Buy.class, pageable);
         List<Buy> allBuyBids = buyOrderQueryFacade.findAllBuyBidsOf(productId, pageable);
-        List<TradeResponseDto> tradeResponseDtos = allBuyBids.stream()
-            .map(BuyMapper.INSTANCE::toTradeResponseDto)
+        List<BuyTradeResponseDto> buyTradeResponseDtos = allBuyBids.stream()
+            .map(BuyMapper.INSTANCE::toBuyTradeResponseDto)
             .toList();
-        return RestResponse.success(tradeResponseDtos);
+        return RestResponse.success(buyTradeResponseDtos);
     }
 }

--- a/src/main/java/bc1/gream/domain/product/controller/SellTradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/controller/SellTradeResponseDto.java
@@ -1,7 +1,9 @@
 package bc1.gream.domain.product.controller;
 
 import java.time.LocalDateTime;
+import lombok.Builder;
 
+@Builder
 public record SellTradeResponseDto(
     Long sellId,
     Long sellPrice,

--- a/src/main/java/bc1/gream/domain/product/controller/SellTradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/controller/SellTradeResponseDto.java
@@ -1,0 +1,11 @@
+package bc1.gream.domain.product.controller;
+
+import java.time.LocalDateTime;
+
+public record SellTradeResponseDto(
+    Long sellId,
+    Long sellPrice,
+    LocalDateTime tradeDate
+) {
+
+}

--- a/src/main/java/bc1/gream/domain/product/dto/ProductDislikeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/ProductDislikeResponseDto.java
@@ -1,0 +1,8 @@
+package bc1.gream.domain.product.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ProductDislikeResponseDto(String message) {
+
+}

--- a/src/main/java/bc1/gream/domain/product/dto/response/BuyTradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/BuyTradeResponseDto.java
@@ -1,0 +1,13 @@
+package bc1.gream.domain.product.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record BuyTradeResponseDto(
+    Long buyId,
+    Long buyPrice,
+    LocalDateTime tradeDate
+) {
+
+}

--- a/src/main/java/bc1/gream/domain/product/dto/response/OrderTradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/OrderTradeResponseDto.java
@@ -2,9 +2,9 @@ package bc1.gream.domain.product.dto.response;
 
 import java.time.LocalDateTime;
 
-public record TradeResponseDto(
+public record OrderTradeResponseDto(
     Long id,
-    Long price,
+    Long finalPrice,
     LocalDateTime tradeDate
 ) {
 

--- a/src/main/java/bc1/gream/domain/product/dto/response/OrderTradeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/OrderTradeResponseDto.java
@@ -1,7 +1,9 @@
 package bc1.gream.domain.product.dto.response;
 
 import java.time.LocalDateTime;
+import lombok.Builder;
 
+@Builder
 public record OrderTradeResponseDto(
     Long id,
     Long finalPrice,

--- a/src/main/java/bc1/gream/domain/product/dto/response/ProductDetailsResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/ProductDetailsResponseDto.java
@@ -1,6 +1,9 @@
 package bc1.gream.domain.product.dto.response;
 
-public record ProductQueryResponseDto(
+import lombok.Builder;
+
+@Builder
+public record ProductDetailsResponseDto(
     Long id,
     String brand,
     String name,

--- a/src/main/java/bc1/gream/domain/product/dto/response/ProductDislikeResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/ProductDislikeResponseDto.java
@@ -1,4 +1,4 @@
-package bc1.gream.domain.product.dto;
+package bc1.gream.domain.product.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/bc1/gream/domain/product/dto/response/ProductPreviewResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/ProductPreviewResponseDto.java
@@ -1,0 +1,15 @@
+package bc1.gream.domain.product.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ProductPreviewResponseDto(
+    Long id,
+    String brand,
+    String name,
+    String imageUrl,
+    String description,
+    Long price
+) {
+
+}

--- a/src/main/java/bc1/gream/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/bc1/gream/domain/product/mapper/ProductMapper.java
@@ -1,5 +1,6 @@
 package bc1.gream.domain.product.mapper;
 
+import bc1.gream.domain.product.dto.ProductDislikeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductLikeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductQueryResponseDto;
 import bc1.gream.domain.product.entity.Product;
@@ -15,4 +16,6 @@ public interface ProductMapper {
     ProductQueryResponseDto toQueryResponseDto(Product product);
 
     ProductLikeResponseDto toLikeResponseDto(String message);
+
+    ProductDislikeResponseDto toDislikeResponseDto(String message);
 }

--- a/src/main/java/bc1/gream/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/bc1/gream/domain/product/mapper/ProductMapper.java
@@ -1,8 +1,9 @@
 package bc1.gream.domain.product.mapper;
 
-import bc1.gream.domain.product.dto.ProductDislikeResponseDto;
+import bc1.gream.domain.product.dto.response.ProductDetailsResponseDto;
+import bc1.gream.domain.product.dto.response.ProductDislikeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductLikeResponseDto;
-import bc1.gream.domain.product.dto.response.ProductQueryResponseDto;
+import bc1.gream.domain.product.dto.response.ProductPreviewResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -13,9 +14,11 @@ public interface ProductMapper {
 
     ProductMapper INSTANCE = Mappers.getMapper(ProductMapper.class);
 
-    ProductQueryResponseDto toQueryResponseDto(Product product);
+    ProductDetailsResponseDto toDetailsResponseDto(Product product);
 
     ProductLikeResponseDto toLikeResponseDto(String message);
 
     ProductDislikeResponseDto toDislikeResponseDto(String message);
+
+    ProductPreviewResponseDto toPreviewResponseDto(Product product);
 }

--- a/src/main/java/bc1/gream/domain/sell/mapper/SellMapper.java
+++ b/src/main/java/bc1/gream/domain/sell/mapper/SellMapper.java
@@ -1,8 +1,8 @@
 package bc1.gream.domain.sell.mapper;
 
+import bc1.gream.domain.product.controller.SellTradeResponseDto;
 import bc1.gream.domain.sell.dto.response.SellBidResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
-import bc1.gream.domain.product.dto.response.TradeResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -15,7 +15,8 @@ public interface SellMapper {
     @Mapping(source = "id", target = "sellId")
     SellBidResponseDto toSellBidResponseDto(Sell sell);
 
-    @Mapping(target = "price", source = "price")
-    @Mapping(target = "tradeDate", source = "createdAt")
-    TradeResponseDto toTradeResponseDto(Sell sell);
+    @Mapping(source = "id", target = "sellId")
+    @Mapping(source = "price", target = "sellPrice")
+    @Mapping(source = "createdAt", target = "tradeDate")
+    SellTradeResponseDto toSellTradeResponseDto(Sell sell);
 }

--- a/src/test/java/bc1/gream/domain/order/mapper/OrderMapperTest.java
+++ b/src/test/java/bc1/gream/domain/order/mapper/OrderMapperTest.java
@@ -2,7 +2,7 @@ package bc1.gream.domain.order.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import bc1.gream.domain.product.dto.response.TradeResponseDto;
+import bc1.gream.domain.product.dto.response.OrderTradeResponseDto;
 import bc1.gream.test.OrderTest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -18,10 +18,10 @@ class OrderMapperTest implements OrderTest {
     public void 주문_toTradeResponseDto() {
         // WHEN
         ReflectionTestUtils.setField(TEST_ORDER, "createdAt", LocalDateTime.of(2024, 1, 1, 12, 12));
-        TradeResponseDto tradeResponseDto = orderMapper.ofTradedOrder(TEST_ORDER);
+        OrderTradeResponseDto orderTradeResponseDto = orderMapper.toOrderTradeResponseDto(TEST_ORDER);
 
         // THEN
-        assertEquals(TEST_ORDER_FINAL_PRICE, tradeResponseDto.price());
-        assertEquals(TEST_ORDER.getCreatedAt(), tradeResponseDto.tradeDate());
+        assertEquals(TEST_ORDER_FINAL_PRICE, orderTradeResponseDto.finalPrice());
+        assertEquals(TEST_ORDER.getCreatedAt(), orderTradeResponseDto.tradeDate());
     }
 }

--- a/src/test/java/bc1/gream/domain/product/mapper/ProductMapperTest.java
+++ b/src/test/java/bc1/gream/domain/product/mapper/ProductMapperTest.java
@@ -2,8 +2,8 @@ package bc1.gream.domain.product.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bc1.gream.domain.product.dto.response.ProductDetailsResponseDto;
 import bc1.gream.domain.product.dto.response.ProductLikeResponseDto;
-import bc1.gream.domain.product.dto.response.ProductQueryResponseDto;
 import bc1.gream.test.ProductTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +16,13 @@ class ProductMapperTest implements ProductTest {
     @DisplayName("상품을 입력받아 ProductQueryResponseDto로 변환합니다.")
     public void 상품_toProductQueryResponseDto() {
         // WHEN
-        ProductQueryResponseDto productQueryResponseDto = productMapperImpl.toQueryResponseDto(TEST_PRODUCT);
+        ProductDetailsResponseDto productDetailsResponseDto = productMapperImpl.toDetailsResponseDto(TEST_PRODUCT);
 
         // THEN
-        assertEquals(TEST_PRODUCT_IMAGE_URL, productQueryResponseDto.imageUrl());
-        assertEquals(TEST_PRODUCT_PRICE, productQueryResponseDto.price());
-        assertEquals(TEST_PRODUCT_NAME, productQueryResponseDto.name());
-        assertEquals(TEST_PRODUCT_DESCRIPTION, productQueryResponseDto.description());
+        assertEquals(TEST_PRODUCT_IMAGE_URL, productDetailsResponseDto.imageUrl());
+        assertEquals(TEST_PRODUCT_PRICE, productDetailsResponseDto.price());
+        assertEquals(TEST_PRODUCT_NAME, productDetailsResponseDto.name());
+        assertEquals(TEST_PRODUCT_DESCRIPTION, productDetailsResponseDto.description());
     }
 
     @Test


### PR DESCRIPTION
## 개요
각 API 별 반환 DTO 타입 변경

## 작업사항
- 판매입찰 조회 반환 DTO 수정

- Product 목록 / 단건 조회 반환 DTO 수정
  - 목록 조회 반환 DTO -> ProductPreviewResponseDto
  - 단건 조회 반환 DTO -> ProductDetailsResponseDto

- OrderTradeResponseDto @builder 추가

- 체결내역 조회 반환 DTO 수정

- 구매 입찰가 조회 반환 DTO 수정

- BuyController 에 javadoc 추가

- 관심상품 취소 반환 DTO 타입 변경
  - (이전) ProductLikeResponseDto -> (이후) ProductDislikeResponseDto

## 관련 이슈
- close #110 
