### PR TITLE
입찰 조회 시, 최근 입찰 순으로 조회 수정

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
@@ -16,10 +16,14 @@ public final class BuyQueryOrderFactory {
 
         List<OrderSpecifier> orders = new ArrayList<>();
 
+        if (sort.isEmpty()) {
+            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, buy, "createdAt");
+            orders.add(orderCreatedAt);
+        }
+
         if (!ObjectUtils.isEmpty(sort)) {
             for (Sort.Order order : sort) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-
                 switch (order.getProperty()) {
                     case "id" -> {
                         OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction, buy, "id");
@@ -38,6 +42,7 @@ public final class BuyQueryOrderFactory {
                 }
             }
         }
+
         return orders.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
@@ -17,10 +17,14 @@ public final class SellQueryOrderFactory {
 
         List<OrderSpecifier> orders = new ArrayList<>();
 
+        if (sort.isEmpty()) {
+            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, sell, "createdAt");
+            orders.add(orderCreatedAt);
+        }
+
         if (!ObjectUtils.isEmpty(sort)) {
             for (Sort.Order order : sort) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-
                 switch (order.getProperty()) {
                     case "id" -> {
                         OrderSpecifier<?> orderId = QueryDslUtil.getSortedColumn(direction, sell, "id");
@@ -35,10 +39,13 @@ public final class SellQueryOrderFactory {
                         orders.add(orderCreatedAt);
                     }
                     default -> {
+                        OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, sell, "createdAt");
+                        orders.add(orderCreatedAt);
                     }
                 }
             }
         }
+
         return orders.toArray(OrderSpecifier[]::new);
     }
 

--- a/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.buy.entity.Buy;
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.common.ResultCase;
@@ -40,11 +41,12 @@ class BuyRepositoryCustomImplTest implements BuyTest {
     @Autowired
     private BuyRepository buyRepository;
     private Buy savedBuy;
+    private Product savedProduct;
 
     @BeforeEach
     void setUp() {
         userRepository.save(TEST_USER);
-        productRepository.save(TEST_PRODUCT);
+        savedProduct = productRepository.save(TEST_PRODUCT);
         savedBuy = buyRepository.save(TEST_BUY);
     }
 
@@ -74,14 +76,14 @@ class BuyRepositoryCustomImplTest implements BuyTest {
                     .price(TEST_BUY_PRICE)
                     .deadlineAt(TEST_DEADLINE_AT)
                     .user(TEST_USER)
-                    .product(TEST_PRODUCT)
+                    .product(savedProduct)
                     .build()
             );
 
         }
 
         // WHEN
-        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(TEST_PRODUCT_ID, TEST_BUY_PRICE)
+        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(savedProduct.getId(), TEST_BUY_PRICE)
             .orElseThrow(() -> new GlobalException(ResultCase.BUY_BID_NOT_FOUND));
 
         // THEN

--- a/src/test/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactoryTest.java
+++ b/src/test/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactoryTest.java
@@ -1,15 +1,15 @@
-package bc1.gream.domain.sell.repository.helper;
+package bc1.gream.domain.buy.repository.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import bc1.gream.domain.sell.entity.QSell;
+import bc1.gream.domain.buy.entity.QBuy;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-class SellQueryOrderFactoryTest {
+class BuyQueryOrderFactoryTest {
 
     @Test
     public void 기본정렬기준생성() {
@@ -17,10 +17,10 @@ class SellQueryOrderFactoryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // WHEN
-        OrderSpecifier[] orders = SellQueryOrderFactory.getOrdersOf(pageable.getSort());
+        OrderSpecifier[] orders = BuyQueryOrderFactory.getOrdersOf(pageable.getSort());
 
         // THEN
         assertEquals(Order.DESC, orders[0].getOrder());
-        assertEquals(QSell.sell.createdAt, orders[0].getTarget());
+        assertEquals(QBuy.buy.createdAt, orders[0].getTarget());
     }
 }

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
 import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
-import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.config.QueryDslConfig;
@@ -53,8 +53,20 @@ class SellRepositoryCustomImplTest implements SellTest {
     void setUp() {
         user = userRepository.save(TEST_USER);
         product = productRepository.save(TEST_PRODUCT);
-        gifticon = gifticonRepository.save(TEST_GIFTICON);
-        sell = sellRepository.save(TEST_SELL);
+        Gifticon gifticon = gifticonRepository.save(Gifticon.builder()
+            .gifticonUrl(TEST_GIFTICON_URL)
+            .order(null)
+            .build()
+        );
+        sell = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(TEST_DEADLINE_AT)
+                .product(product)
+                .user(user)
+                .gifticon(gifticon)
+                .build()
+        );
     }
 
     @Test
@@ -64,7 +76,7 @@ class SellRepositoryCustomImplTest implements SellTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
 
         // WHEN
-        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
+        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(product, pageable);
 
         // THEN
         boolean hasSellBid = allPricesOf.stream()

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -1,12 +1,13 @@
 package bc1.gream.domain.sell.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
 import bc1.gream.domain.order.entity.Gifticon;
-import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.config.QueryDslConfig;
@@ -64,9 +65,54 @@ class SellRepositoryCustomImplTest implements SellTest {
 
         // WHEN
         Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
+
         // THEN
         boolean hasSellBid = allPricesOf.stream()
             .anyMatch(s -> s.equals(sell));
         assertTrue(hasSellBid);
+    }
+
+    @Test
+    @DisplayName("상품에 대한 판매입찰 인스턴스를 조회, 페이징 처리 시, 기본 순서는 최근 날짜순서입니다.")
+    public void 상품_판매입찰_조회_페이징_기본순서_최근날짜순() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 10);
+        Gifticon pastGifticon = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
+                .build()
+        );
+        Sell pastSell = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(TEST_DEADLINE_AT)
+                .product(product)
+                .user(user)
+                .gifticon(pastGifticon)
+                .build()
+        );
+        Gifticon recentGifticon = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
+                .build()
+        );
+        Sell recentSell = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(TEST_DEADLINE_AT)
+                .product(product)
+                .user(user)
+                .gifticon(recentGifticon)
+                .build()
+        );
+
+        // WHEN
+        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
+
+        // THEN
+        assertEquals(recentSell, allPricesOf.getContent().get(0));
+        assertEquals(pastSell, allPricesOf.getContent().get(1));
     }
 }

--- a/src/test/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactoryTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactoryTest.java
@@ -1,0 +1,26 @@
+package bc1.gream.domain.sell.repository.helper;
+
+import com.querydsl.core.types.OrderSpecifier;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+class SellQueryOrderFactoryTest {
+
+    @Test
+    public void 기본정렬기준생성() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // WHEN
+        OrderSpecifier[] orders = SellQueryOrderFactory.getOrdersOf(pageable.getSort());
+
+        // THEN
+        for (OrderSpecifier os : orders) {
+            System.out.println("os.getOrder() = " + os.getOrder());
+            System.out.println("os.getTarget() = " + os.getTarget());
+            System.out.println("os = " + os);
+        }
+    }
+
+}

--- a/src/test/java/bc1/gream/test/GifticonTest.java
+++ b/src/test/java/bc1/gream/test/GifticonTest.java
@@ -15,5 +15,6 @@ public interface GifticonTest extends OrderTest {
 
     Gifticon TEST_GIFTICON = Gifticon.builder()
         .gifticonUrl(TEST_GIFTICON_URL)
+        .order(null)
         .build();
 }


### PR DESCRIPTION
## 개요
> 입찰 조회 시, 최근 입찰 순으로 조회

## 작업사항
- 판매입찰 조회 시, 최근 순서대로 조회 기능으로 변경
- 구매입찰 조회 시, 최근 순서대로 조회 기능으로 변경
- BuyRepositoryCustomImplTest 테스트 케이스 내 연관관계 매핑 처리 변경

## 관련 이슈
- close #108
