### PR TITLE
체결거래내역 조회 시, 최근 순서대로 조회 기능

### DIFF
--- a/src/main/java/bc1/gream/domain/common/model/BaseEntity.java
+++ b/src/main/java/bc1/gream/domain/common/model/BaseEntity.java
@@ -16,8 +16,8 @@ public abstract class BaseEntity {
 
     @Column(updatable = false)
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 }

--- a/src/main/java/bc1/gream/domain/order/entity/Order.java
+++ b/src/main/java/bc1/gream/domain/order/entity/Order.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,11 +56,14 @@ public class Order extends BaseEntity {
     private Long expectedPrice; // 구매희망가격
 
     @Builder
-    private Order(Product product, User buyer, User seller, Long finalPrice, Long expectedPrice) {
+    private Order(Product product, User buyer, User seller, Long finalPrice, Long expectedPrice, LocalDateTime createdAt,
+        LocalDateTime modifiedAt) {
         this.product = product;
         this.buyer = buyer;
         this.seller = seller;
         this.finalPrice = finalPrice;
         this.expectedPrice = expectedPrice;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
     }
 }

--- a/src/main/java/bc1/gream/domain/order/repository/OrderRepository.java
+++ b/src/main/java/bc1/gream/domain/order/repository/OrderRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    List<Order> findAllByProduct(Product product);
+    List<Order> findAllByProductOrderByCreatedAtDesc(Product product);
 }

--- a/src/main/java/bc1/gream/domain/order/service/query/OrderQueryService.java
+++ b/src/main/java/bc1/gream/domain/order/service/query/OrderQueryService.java
@@ -16,6 +16,6 @@ public class OrderQueryService {
     private final OrderRepository orderRepository;
 
     public List<Order> findAllTradesOf(Product product) {
-        return orderRepository.findAllByProduct(product);
+        return orderRepository.findAllByProductOrderByCreatedAtDesc(product);
     }
 }

--- a/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.buy.entity.Buy;
+import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.common.ResultCase;
@@ -40,11 +41,12 @@ class BuyRepositoryCustomImplTest implements BuyTest {
     @Autowired
     private BuyRepository buyRepository;
     private Buy savedBuy;
+    private Product savedProduct;
 
     @BeforeEach
     void setUp() {
         userRepository.save(TEST_USER);
-        productRepository.save(TEST_PRODUCT);
+        savedProduct = productRepository.save(TEST_PRODUCT);
         savedBuy = buyRepository.save(TEST_BUY);
     }
 
@@ -55,7 +57,7 @@ class BuyRepositoryCustomImplTest implements BuyTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
 
         // WHEN
-        Page<Buy> allPricesOf = buyRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
+        Page<Buy> allPricesOf = buyRepositoryCustom.findAllPricesOf(savedProduct, pageable);
 
         // THEN
         boolean hasBuyBid = allPricesOf.stream()
@@ -74,14 +76,14 @@ class BuyRepositoryCustomImplTest implements BuyTest {
                     .price(TEST_BUY_PRICE)
                     .deadlineAt(TEST_DEADLINE_AT)
                     .user(TEST_USER)
-                    .product(TEST_PRODUCT)
+                    .product(savedProduct)
                     .build()
             );
 
         }
 
         // WHEN
-        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(TEST_PRODUCT_ID, TEST_BUY_PRICE)
+        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(savedProduct.getId(), TEST_BUY_PRICE)
             .orElseThrow(() -> new GlobalException(ResultCase.BUY_BID_NOT_FOUND));
 
         // THEN

--- a/src/test/java/bc1/gream/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/bc1/gream/domain/order/repository/OrderRepositoryTest.java
@@ -1,0 +1,86 @@
+package bc1.gream.domain.order.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bc1.gream.domain.order.entity.Order;
+import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.user.entity.User;
+import bc1.gream.domain.user.repository.UserRepository;
+import bc1.gream.global.config.QueryDslConfig;
+import bc1.gream.global.jpa.AuditingConfig;
+import bc1.gream.test.OrderTest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({QueryDslConfig.class, AuditingConfig.class})
+class OrderRepositoryTest implements OrderTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+    private User buyer;
+    private User seller;
+    private Product product;
+    private Order pastOrder;
+    private Order recentOrder;
+
+    @BeforeEach
+    void setUp() {
+        buyer = userRepository.save(TEST_BUYER);
+        seller = userRepository.save(TEST_SELLER);
+        product = productRepository.save(TEST_PRODUCT);
+        pastOrder = orderRepository.save(
+            Order.builder()
+                .product(product)
+                .buyer(buyer)
+                .seller(seller)
+                .finalPrice(TEST_ORDER_FINAL_PRICE)
+                .expectedPrice(TEST_ORDER_EXPECTED_PRICE)
+                .build()
+        );
+        recentOrder = orderRepository.save(
+            Order.builder()
+                .product(product)
+                .buyer(buyer)
+                .seller(seller)
+                .finalPrice(TEST_ORDER_FINAL_PRICE)
+                .expectedPrice(TEST_ORDER_EXPECTED_PRICE)
+                .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        orderRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("가장 최근 순으로 거래가를 조회합니다.")
+    public void 가장최근순_거래가_조회() {
+        // WHEN
+        List<Order> tradedOrders = orderRepository.findAllByProductOrderByCreatedAtDesc(product);
+
+        // THEN
+        assertEquals(2, tradedOrders.size());
+        assertEquals(recentOrder, tradedOrders.get(0));
+        assertEquals(pastOrder, tradedOrders.get(1));
+    }
+}

--- a/src/test/java/bc1/gream/domain/order/service/query/OrderQueryServiceTest.java
+++ b/src/test/java/bc1/gream/domain/order/service/query/OrderQueryServiceTest.java
@@ -1,0 +1,53 @@
+package bc1.gream.domain.order.service.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bc1.gream.domain.order.entity.Order;
+import bc1.gream.domain.order.repository.OrderRepository;
+import bc1.gream.domain.product.entity.Product;
+import bc1.gream.test.OrderTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class OrderQueryServiceTest implements OrderTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @InjectMocks
+    private OrderQueryService orderQueryService;
+
+    @Test
+    @DisplayName("가장 최근 순으로 거래가를 조회합니다.")
+    public void 가장최근순_거래가_조회() {
+        // GIVEN
+        Product mockProduct = mock(Product.class);
+        Order pastOrder = Order.builder()
+            .createdAt(LocalDateTime.of(2024, 1, 1, 12, 12))
+            .build();
+        Order recentOrder = Order.builder()
+            .createdAt(LocalDateTime.of(2024, 1, 13, 12, 12))
+            .build();
+        List<Order> mockOrders = List.of(recentOrder, pastOrder);
+
+        // WHEN
+        when(orderRepository.findAllByProductOrderByCreatedAtDesc(mockProduct))
+            .thenReturn(mockOrders);
+        List<Order> trades = orderQueryService.findAllTradesOf(mockProduct);
+
+        // THEN
+        assertEquals(2, trades.size());
+        assertEquals(recentOrder, trades.get(0));
+        assertEquals(pastOrder, trades.get(1));
+    }
+}

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
 import bc1.gream.domain.order.entity.Gifticon;
-import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.config.QueryDslConfig;
@@ -35,7 +35,6 @@ class SellRepositoryCustomImplTest implements SellTest {
     User user;
     Product product;
     Sell sell;
-    Gifticon gifticon;
 
     @Autowired
     private SellRepositoryCustomImpl sellRepositoryCustom;
@@ -52,8 +51,20 @@ class SellRepositoryCustomImplTest implements SellTest {
     void setUp() {
         user = userRepository.save(TEST_USER);
         product = productRepository.save(TEST_PRODUCT);
-        gifticon = gifticonRepository.save(TEST_GIFTICON);
-        sell = sellRepository.save(TEST_SELL);
+        Gifticon gifticon = gifticonRepository.save(Gifticon.builder()
+            .gifticonUrl(TEST_GIFTICON_URL)
+            .order(null)
+            .build()
+        );
+        sell = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(TEST_DEADLINE_AT)
+                .product(product)
+                .user(user)
+                .gifticon(gifticon)
+                .build()
+        );
     }
 
     @Test
@@ -63,7 +74,8 @@ class SellRepositoryCustomImplTest implements SellTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
 
         // WHEN
-        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
+        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(product, pageable);
+
         // THEN
         boolean hasSellBid = allPricesOf.stream()
             .anyMatch(s -> s.equals(sell));

--- a/src/test/java/bc1/gream/test/GifticonTest.java
+++ b/src/test/java/bc1/gream/test/GifticonTest.java
@@ -15,6 +15,5 @@ public interface GifticonTest extends OrderTest {
 
     Gifticon TEST_GIFTICON = Gifticon.builder()
         .gifticonUrl(TEST_GIFTICON_URL)
-        .order(null)
         .build();
 }

--- a/src/test/java/bc1/gream/test/GifticonTest.java
+++ b/src/test/java/bc1/gream/test/GifticonTest.java
@@ -15,5 +15,6 @@ public interface GifticonTest extends OrderTest {
 
     Gifticon TEST_GIFTICON = Gifticon.builder()
         .gifticonUrl(TEST_GIFTICON_URL)
+        .order(null)
         .build();
 }


### PR DESCRIPTION
## 개요
최근 순서대로 체결내역 조회

## 작업사항
- GifticonTest Defulat 테스트 케이스의 Order 매핑을 null 처리로 수정
- 판매내역 조회 시, 최근 순서대로 조회 기능으로 변경
- Order 에 createdAt, modifiedAt 값 삽입 가능하게 생성자 변경 
- SellRepositoryCustomImplTest / BuyRepositoryCustomImplTest  Test Method 수행 시, 저장된 엔티티 사용하여 수행하게끔 변경

## 관련 이슈
- close #114 
