### PR TITLE
판매입찰내역/구매입찰내역 조회 순서 및 매핑 정렬 

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustom.java
@@ -1,6 +1,7 @@
 package bc1.gream.domain.buy.repository;
 
 import bc1.gream.domain.buy.entity.Buy;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,6 @@ public interface BuyRepositoryCustom {
     Page<Buy> findAllPricesOf(Product product, Pageable pageable);
 
     Optional<Buy> findByProductIdAndPrice(Long productId, Long price);
+
+    Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable);
 }

--- a/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImpl.java
@@ -5,9 +5,11 @@ import static bc1.gream.domain.buy.entity.QBuy.buy;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.entity.QBuy;
 import bc1.gream.domain.buy.repository.helper.BuyQueryOrderFactory;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.entity.QProduct;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +25,13 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 상품에 대한 전체 구매입찰 조건조회,페이징 처리
+     *
+     * @param product  상품
+     * @param pageable 페이징
+     * @return 구매입찰
+     */
     @Override
     public Page<Buy> findAllPricesOf(Product product, Pageable pageable) {
         // Get Orders By Columns
@@ -38,9 +47,23 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(buys, pageable, buys::size);
+        JPAQuery<Long> countQuery = queryFactory
+            .select(buy.count())
+            .from(buy)
+            .leftJoin(buy.product, QProduct.product)
+            .where(buy.product.eq(product))
+            .orderBy(orderSpecifiers);
+
+        return PageableExecutionUtils.getPage(buys, pageable, countQuery::fetchOne);
     }
 
+    /**
+     * 상품 id와 가격에 대해 가장 먼저 생성된 구매입찰 반환
+     *
+     * @param productId 상품 id
+     * @param price     가격
+     * @return 가장 먼저 생성된 구매입찰
+     */
     @Override
     public Optional<Buy> findByProductIdAndPrice(Long productId, Long price) {
         Buy buy = queryFactory
@@ -50,5 +73,45 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
             .orderBy(QBuy.buy.createdAt.asc())
             .fetchFirst();
         return Optional.ofNullable(buy);
+    }
+
+    /**
+     * 상품에 대한 구매입찰가격수량에 대한 조건조회,페이징 처리. 기본정렬은 가격 내림차순
+     *
+     * @param product  상품
+     * @param pageable 페이징
+     * @return 구매입찰가격수량
+     */
+    @Override
+    public Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable) {
+        // Get Orders By Columns
+        OrderSpecifier[] orderSpecifiers = BuyQueryOrderFactory.getOrdersOf(pageable.getSort());
+
+        // Query + Order + Paging
+        List<BuyPriceToQuantityResponseDto> buyPriceToQuantityResponseDtos = queryFactory
+            .select(buy.price, buy.count())
+            .from(buy)
+            .where(buy.product.eq(product))
+            .groupBy(buy.price)
+            .orderBy(orderSpecifiers)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch()
+            .stream()
+            .map(tuple -> BuyPriceToQuantityResponseDto.builder()
+                .buyPrice(tuple.get(buy.price))
+                .quantity(tuple.get(buy.count()))
+                .build()
+            )
+            .toList();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(buy.count())
+            .from(buy)
+            .where(buy.product.eq(product))
+            .groupBy(buy.price)
+            .orderBy(orderSpecifiers);
+
+        return PageableExecutionUtils.getPage(buyPriceToQuantityResponseDtos, pageable, countQuery::fetchOne);
     }
 }

--- a/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
@@ -12,6 +12,12 @@ import org.springframework.util.ObjectUtils;
 
 public final class BuyQueryOrderFactory {
 
+    /**
+     * 정렬기준에 따른 Buy에 대한 정렬배열, 기본은 가격 내림차순
+     *
+     * @param sort 정렬 기준
+     * @return
+     */
     public static OrderSpecifier[] getOrdersOf(Sort sort) {
 
         List<OrderSpecifier> orders = new ArrayList<>();

--- a/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactory.java
@@ -17,7 +17,7 @@ public final class BuyQueryOrderFactory {
         List<OrderSpecifier> orders = new ArrayList<>();
 
         if (sort.isEmpty()) {
-            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, buy, "createdAt");
+            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, buy, "price");
             orders.add(orderCreatedAt);
         }
 

--- a/src/main/java/bc1/gream/domain/buy/service/BuyService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/BuyService.java
@@ -6,6 +6,7 @@ import static bc1.gream.global.common.ResultCase.NOT_AUTHORIZED;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
@@ -50,8 +51,8 @@ public class BuyService {
      * @return 구매입찰가 내역 페이징 데이터
      */
     @Transactional(readOnly = true)
-    public Page<Buy> findAllBuyBidsOf(Product product, Pageable pageable) {
-        return buyRepository.findAllPricesOf(product, pageable);
+    public Page<BuyPriceToQuantityResponseDto> findAllBuyBidsOf(Product product, Pageable pageable) {
+        return buyRepository.findAllPriceToQuantityOf(product, pageable);
     }
 
     /**

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -3,8 +3,6 @@ package bc1.gream.domain.product.controller;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.mapper.BuyMapper;
 import bc1.gream.domain.common.facade.BuyOrderQueryFacade;
-import bc1.gream.domain.common.facade.ProductOrderQueryFacade;
-import bc1.gream.domain.common.facade.SellOrderQueryFacade;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.mapper.OrderMapper;
 import bc1.gream.domain.product.dto.response.BuyTradeResponseDto;
@@ -13,10 +11,11 @@ import bc1.gream.domain.product.dto.response.ProductDetailsResponseDto;
 import bc1.gream.domain.product.dto.response.ProductPreviewResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.mapper.ProductMapper;
+import bc1.gream.domain.product.provider.SellOrderQueryProvider;
 import bc1.gream.domain.product.service.query.ProductService;
-import bc1.gream.domain.sell.dto.response.SellTradeResponseDto;
+import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
-import bc1.gream.domain.sell.mapper.SellMapper;
+import bc1.gream.domain.sell.provider.ProductOrderQueryProvider;
 import bc1.gream.global.common.RestResponse;
 import bc1.gream.global.validator.OrderCriteriaValidator;
 import java.util.List;
@@ -37,8 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductQueryController {
 
     private final ProductService productService;
-    private final ProductOrderQueryFacade productOrderQueryFacade;
-    private final SellOrderQueryFacade sellOrderQueryFacade;
+    private final ProductOrderQueryProvider productOrderQueryProvider;
+    private final SellOrderQueryProvider sellOrderQueryProvider;
     private final BuyOrderQueryFacade buyOrderQueryFacade;
 
     /**
@@ -72,7 +71,7 @@ public class ProductQueryController {
     public RestResponse<List<OrderTradeResponseDto>> findAllTrades(
         @PathVariable("id") Long productId
     ) {
-        List<Order> allTrades = productOrderQueryFacade.findAllTradesOf(productId);
+        List<Order> allTrades = productOrderQueryProvider.findAllTradesOf(productId);
         List<OrderTradeResponseDto> orderTradeResponseDtos = allTrades.stream()
             .map(OrderMapper.INSTANCE::toOrderTradeResponseDto)
             .toList();
@@ -83,16 +82,14 @@ public class ProductQueryController {
      * 판매 입찰가 조회
      */
     @GetMapping("/{id}/sell")
-    public RestResponse<List<SellTradeResponseDto>> findAllSellBidPrices(
+    public RestResponse<List<SellPriceToQuantityResponseDto>> findAllSellBidPrices(
         @PathVariable("id") Long productId,
         @PageableDefault(size = 5) Pageable pageable
     ) {
         OrderCriteriaValidator.validateOrderCriteria(Sell.class, pageable);
-        List<Sell> allSellBids = sellOrderQueryFacade.findAllSellBidsOf(productId, pageable);
-        List<SellTradeResponseDto> sellTradeResponseDtos = allSellBids.stream()
-            .map(SellMapper.INSTANCE::toSellTradeResponseDto)
-            .toList();
-        return RestResponse.success(sellTradeResponseDtos);
+        List<SellPriceToQuantityResponseDto> sellPriceToQuantityResponseDtos = sellOrderQueryProvider.findAllSellBidsOf(productId,
+            pageable);
+        return RestResponse.success(sellPriceToQuantityResponseDtos);
     }
 
     /**

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -1,19 +1,18 @@
 package bc1.gream.domain.product.controller;
 
 import bc1.gream.domain.buy.entity.Buy;
-import bc1.gream.domain.buy.mapper.BuyMapper;
-import bc1.gream.domain.common.facade.BuyOrderQueryFacade;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.mapper.OrderMapper;
-import bc1.gream.domain.product.dto.response.BuyTradeResponseDto;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.dto.response.OrderTradeResponseDto;
 import bc1.gream.domain.product.dto.response.ProductDetailsResponseDto;
 import bc1.gream.domain.product.dto.response.ProductPreviewResponseDto;
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.mapper.ProductMapper;
+import bc1.gream.domain.product.provider.BuyOrderQueryProvider;
 import bc1.gream.domain.product.provider.SellOrderQueryProvider;
 import bc1.gream.domain.product.service.query.ProductService;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.provider.ProductOrderQueryProvider;
 import bc1.gream.global.common.RestResponse;
@@ -38,7 +37,7 @@ public class ProductQueryController {
     private final ProductService productService;
     private final ProductOrderQueryProvider productOrderQueryProvider;
     private final SellOrderQueryProvider sellOrderQueryProvider;
-    private final BuyOrderQueryFacade buyOrderQueryFacade;
+    private final BuyOrderQueryProvider buyOrderQueryProvider;
 
     /**
      * 상품 전체 조회
@@ -96,15 +95,12 @@ public class ProductQueryController {
      * 구매 입찰가 조회
      */
     @GetMapping("/{id}/buy")
-    public RestResponse<List<BuyTradeResponseDto>> findAllBuyBidPrices(
+    public RestResponse<List<BuyPriceToQuantityResponseDto>> findAllBuyBidPrices(
         @PathVariable("id") Long productId,
         @PageableDefault(size = 5) Pageable pageable
     ) {
         OrderCriteriaValidator.validateOrderCriteria(Buy.class, pageable);
-        List<Buy> allBuyBids = buyOrderQueryFacade.findAllBuyBidsOf(productId, pageable);
-        List<BuyTradeResponseDto> buyTradeResponseDtos = allBuyBids.stream()
-            .map(BuyMapper.INSTANCE::toBuyTradeResponseDto)
-            .toList();
-        return RestResponse.success(buyTradeResponseDtos);
+        List<BuyPriceToQuantityResponseDto> buyPriceToQuantityResponseDtos = buyOrderQueryProvider.findAllBuyBidsOf(productId, pageable);
+        return RestResponse.success(buyPriceToQuantityResponseDtos);
     }
 }

--- a/src/main/java/bc1/gream/domain/product/dto/response/BuyPriceToQuantityResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/BuyPriceToQuantityResponseDto.java
@@ -1,0 +1,11 @@
+package bc1.gream.domain.product.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BuyPriceToQuantityResponseDto(
+    Long buyPrice,
+    Long quantity
+) {
+
+}

--- a/src/main/java/bc1/gream/domain/product/dto/response/SellPriceToQuantityResponseDto.java
+++ b/src/main/java/bc1/gream/domain/product/dto/response/SellPriceToQuantityResponseDto.java
@@ -1,4 +1,4 @@
-package bc1.gream.domain.sell.dto.response;
+package bc1.gream.domain.product.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/bc1/gream/domain/product/provider/BuyOrderQueryProvider.java
+++ b/src/main/java/bc1/gream/domain/product/provider/BuyOrderQueryProvider.java
@@ -1,7 +1,7 @@
-package bc1.gream.domain.common.facade;
+package bc1.gream.domain.product.provider;
 
-import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.service.BuyService;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.service.query.ProductService;
 import java.util.List;
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class BuyOrderQueryFacade {
+public class BuyOrderQueryProvider {
 
     private final ProductService productQueryService;
     private final BuyService buyService;
@@ -26,7 +26,7 @@ public class BuyOrderQueryFacade {
      * @return 해당 상품에 대한 구매입찰 내역
      * @author 임지훈
      */
-    public List<Buy> findAllBuyBidsOf(Long productId, Pageable pageable) {
+    public List<BuyPriceToQuantityResponseDto> findAllBuyBidsOf(Long productId, Pageable pageable) {
         Product product = productQueryService.findBy(productId);
         return buyService.findAllBuyBidsOf(product, pageable).getContent();
     }

--- a/src/main/java/bc1/gream/domain/product/provider/SellOrderQueryProvider.java
+++ b/src/main/java/bc1/gream/domain/product/provider/SellOrderQueryProvider.java
@@ -1,9 +1,9 @@
-package bc1.gream.domain.common.facade;
+package bc1.gream.domain.product.provider;
 
-import bc1.gream.domain.sell.entity.Sell;
-import bc1.gream.domain.sell.service.SellService;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.service.query.ProductService;
+import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
+import bc1.gream.domain.sell.service.SellService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class   SellOrderQueryFacade {
+public class SellOrderQueryProvider {
 
     private final ProductService productService;
     private final SellService sellService;
@@ -27,7 +27,7 @@ public class   SellOrderQueryFacade {
      * @return 해당 상품에 대한 판매입찰 내역
      * @author 임지훈
      */
-    public List<Sell> findAllSellBidsOf(Long productId, Pageable pageable) {
+    public List<SellPriceToQuantityResponseDto> findAllSellBidsOf(Long productId, Pageable pageable) {
         Product product = productService.findBy(productId);
         return sellService.findAllSellBidsOf(product, pageable).getContent();
     }

--- a/src/main/java/bc1/gream/domain/product/provider/SellOrderQueryProvider.java
+++ b/src/main/java/bc1/gream/domain/product/provider/SellOrderQueryProvider.java
@@ -1,8 +1,8 @@
 package bc1.gream.domain.product.provider;
 
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.service.query.ProductService;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.service.SellService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/bc1/gream/domain/sell/dto/response/SellPriceToQuantityResponseDto.java
+++ b/src/main/java/bc1/gream/domain/sell/dto/response/SellPriceToQuantityResponseDto.java
@@ -1,0 +1,11 @@
+package bc1.gream.domain.sell.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SellPriceToQuantityResponseDto(
+    Long sellPrice,
+    Long quantity
+) {
+
+}

--- a/src/main/java/bc1/gream/domain/sell/provider/ProductOrderQueryProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/ProductOrderQueryProvider.java
@@ -1,4 +1,4 @@
-package bc1.gream.domain.common.facade;
+package bc1.gream.domain.sell.provider;
 
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.service.query.OrderQueryService;
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ProductOrderQueryFacade {
+public class ProductOrderQueryProvider {
 
     private final ProductService productService;
     private final OrderQueryService orderQueryService;

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.sell.repository;
 
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
 import java.util.Optional;
 import org.springframework.data.domain.Page;

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
@@ -1,7 +1,8 @@
 package bc1.gream.domain.sell.repository;
 
-import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
+import bc1.gream.domain.sell.entity.Sell;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,6 @@ public interface SellRepositoryCustom {
     Page<Sell> findAllPricesOf(Product product, Pageable pageable);
 
     Optional<Sell> findByProductIdAndPrice(Long productId, Long price);
+
+    Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable);
 }

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
@@ -5,12 +5,13 @@ import static bc1.gream.domain.product.entity.QProduct.product;
 import static bc1.gream.domain.sell.entity.QSell.sell;
 import static bc1.gream.domain.user.entity.QUser.user;
 
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.entity.QProduct;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.helper.SellQueryOrderFactory;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -26,6 +27,13 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 상품에 대한 전체 판매입찰 조건조회,페이징 처리
+     *
+     * @param product  상품
+     * @param pageable 페이징
+     * @return 판매입찰
+     */
     @Override
     public Page<Sell> findAllPricesOf(Product product, Pageable pageable) {
         // Get Orders By Columns
@@ -41,9 +49,23 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(sells, pageable, sells::size);
+        JPAQuery<Long> countQuery = queryFactory
+            .select(sell.count())
+            .from(sell)
+            .leftJoin(sell.product, QProduct.product)
+            .where(sell.product.eq(product))
+            .orderBy(orderSpecifiers);
+
+        return PageableExecutionUtils.getPage(sells, pageable, countQuery::fetchOne);
     }
 
+    /**
+     * 상품 id와 가격에 대해 가장 나중에 생성된 판매입찰 반환
+     *
+     * @param productId 상품 id
+     * @param price     가격
+     * @return 가장 나중에 생성된 판매입찰 반환
+     */
     @Override
     public Optional<Sell> findByProductIdAndPrice(Long productId, Long price) {
         Sell foundSell = queryFactory.selectFrom(sell)
@@ -56,6 +78,13 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
         return Optional.ofNullable(foundSell);
     }
 
+    /**
+     * 상품에 대한 판매입찰가격수량에 대한 조건조회,페이징 처리. 기본정렬은 가격 오름차순
+     *
+     * @param product  상품
+     * @param pageable 페이징
+     * @return 판매입찰가격수량
+     */
     @Override
     public Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable) {
         // Get Orders By Columns

--- a/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
@@ -13,6 +13,12 @@ import org.springframework.util.ObjectUtils;
 
 public final class SellQueryOrderFactory {
 
+    /**
+     * 정렬기준에 따른 Sell에 대한 정렬배열, 기본은 가격 오름차순
+     *
+     * @param sort 정렬 기준
+     * @return
+     */
     public static OrderSpecifier[] getOrdersOf(Sort sort) {
 
         List<OrderSpecifier> orders = new ArrayList<>();

--- a/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactory.java
@@ -18,7 +18,7 @@ public final class SellQueryOrderFactory {
         List<OrderSpecifier> orders = new ArrayList<>();
 
         if (sort.isEmpty()) {
-            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, sell, "createdAt");
+            OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.ASC, sell, "price");
             orders.add(orderCreatedAt);
         }
 
@@ -39,8 +39,6 @@ public final class SellQueryOrderFactory {
                         orders.add(orderCreatedAt);
                     }
                     default -> {
-                        OrderSpecifier<?> orderCreatedAt = QueryDslUtil.getSortedColumn(Order.DESC, sell, "createdAt");
-                        orders.add(orderCreatedAt);
                     }
                 }
             }

--- a/src/main/java/bc1/gream/domain/sell/service/SellService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellService.java
@@ -3,6 +3,7 @@ package bc1.gream.domain.sell.service;
 import static bc1.gream.global.common.ResultCase.SELL_BID_PRODUCT_NOT_FOUND;
 
 import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;
@@ -28,8 +29,8 @@ public class SellService {
      * @return 판매입찰가 내역 페이징 데이터
      */
     @Transactional(readOnly = true)
-    public Page<Sell> findAllSellBidsOf(Product product, Pageable pageable) {
-        return sellRepository.findAllPricesOf(product, pageable);
+    public Page<SellPriceToQuantityResponseDto> findAllSellBidsOf(Product product, Pageable pageable) {
+        return sellRepository.findAllPriceToQuantityOf(product, pageable);
     }
 
 

--- a/src/main/java/bc1/gream/domain/sell/service/SellService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/SellService.java
@@ -2,8 +2,8 @@ package bc1.gream.domain.sell.service;
 
 import static bc1.gream.global.common.ResultCase.SELL_BID_PRODUCT_NOT_FOUND;
 
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;

--- a/src/test/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactoryTest.java
+++ b/src/test/java/bc1/gream/domain/buy/repository/helper/BuyQueryOrderFactoryTest.java
@@ -21,6 +21,6 @@ class BuyQueryOrderFactoryTest {
 
         // THEN
         assertEquals(Order.DESC, orders[0].getOrder());
-        assertEquals(QBuy.buy.createdAt, orders[0].getTarget());
+        assertEquals(QBuy.buy.price, orders[0].getTarget());
     }
 }

--- a/src/test/java/bc1/gream/domain/product/controller/query/ProductQueryControllerTest.java
+++ b/src/test/java/bc1/gream/domain/product/controller/query/ProductQueryControllerTest.java
@@ -5,9 +5,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bc1.gream.domain.common.facade.BuyOrderQueryFacade;
 import bc1.gream.domain.product.controller.ProductQueryController;
 import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.product.provider.BuyOrderQueryProvider;
 import bc1.gream.domain.product.provider.SellOrderQueryProvider;
 import bc1.gream.domain.product.service.query.ProductService;
 import bc1.gream.domain.sell.provider.ProductOrderQueryProvider;
@@ -36,7 +36,7 @@ class ProductQueryControllerTest implements ProductTest {
     @MockBean
     private SellOrderQueryProvider sellOrderQueryProvider;
     @MockBean
-    private BuyOrderQueryFacade buyOrderQueryFacade;
+    private BuyOrderQueryProvider buyOrderQueryProvider;
 
     @BeforeEach
     void setUp() {
@@ -45,7 +45,7 @@ class ProductQueryControllerTest implements ProductTest {
                     productService,
                     productOrderQueryProvider,
                     sellOrderQueryProvider,
-                    buyOrderQueryFacade
+                    buyOrderQueryProvider
                 ))
             .setCustomArgumentResolvers(
                 new PageableHandlerMethodArgumentResolver()

--- a/src/test/java/bc1/gream/domain/product/controller/query/ProductQueryControllerTest.java
+++ b/src/test/java/bc1/gream/domain/product/controller/query/ProductQueryControllerTest.java
@@ -6,11 +6,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bc1.gream.domain.common.facade.BuyOrderQueryFacade;
-import bc1.gream.domain.common.facade.ProductOrderQueryFacade;
-import bc1.gream.domain.common.facade.SellOrderQueryFacade;
 import bc1.gream.domain.product.controller.ProductQueryController;
 import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.product.provider.SellOrderQueryProvider;
 import bc1.gream.domain.product.service.query.ProductService;
+import bc1.gream.domain.sell.provider.ProductOrderQueryProvider;
 import bc1.gream.test.ProductTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,9 +32,9 @@ class ProductQueryControllerTest implements ProductTest {
     @MockBean
     private ProductService productService;
     @MockBean
-    private ProductOrderQueryFacade productOrderQueryFacade;
+    private ProductOrderQueryProvider productOrderQueryProvider;
     @MockBean
-    private SellOrderQueryFacade sellOrderQueryFacade;
+    private SellOrderQueryProvider sellOrderQueryProvider;
     @MockBean
     private BuyOrderQueryFacade buyOrderQueryFacade;
 
@@ -43,8 +43,8 @@ class ProductQueryControllerTest implements ProductTest {
         this.mockMvc = MockMvcBuilders.standaloneSetup(
                 new ProductQueryController(
                     productService,
-                    productOrderQueryFacade,
-                    sellOrderQueryFacade,
+                    productOrderQueryProvider,
+                    sellOrderQueryProvider,
                     buyOrderQueryFacade
                 ))
             .setCustomArgumentResolvers(

--- a/src/test/java/bc1/gream/domain/product/service/query/impl/ProductOrderQueryProviderImplTest.java
+++ b/src/test/java/bc1/gream/domain/product/service/query/impl/ProductOrderQueryProviderImplTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.BDDMockito.given;
 
-import bc1.gream.domain.common.facade.ProductOrderQueryFacade;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.service.query.OrderQueryService;
 import bc1.gream.domain.product.service.query.ProductService;
+import bc1.gream.domain.sell.provider.ProductOrderQueryProvider;
 import bc1.gream.test.OrderTest;
 import bc1.gream.test.ProductTest;
 import bc1.gream.test.UserTest;
@@ -21,10 +21,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class ProductOrderQueryFacadeImplTest implements UserTest, ProductTest, OrderTest {
+class ProductOrderQueryProviderImplTest implements UserTest, ProductTest, OrderTest {
 
     @InjectMocks
-    ProductOrderQueryFacade productOrderQueryFacade;
+    ProductOrderQueryProvider productOrderQueryProvider;
 
     @Mock
     ProductService productService;
@@ -40,7 +40,7 @@ class ProductOrderQueryFacadeImplTest implements UserTest, ProductTest, OrderTes
         given(orderQueryService.findAllTradesOf(TEST_PRODUCT)).willReturn(List.of(TEST_ORDER));
 
         // WHEN
-        List<Order> allTradesOf = productOrderQueryFacade.findAllTradesOf(TEST_PRODUCT_ID);
+        List<Order> allTradesOf = productOrderQueryProvider.findAllTradesOf(TEST_PRODUCT_ID);
 
         // THEN
         assertFalse(allTradesOf.isEmpty());

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bc1.gream.domain.order.entity.Gifticon;
-import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
+import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.QSell;
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.test.BaseDataRepositoryTest;

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -1,71 +1,143 @@
 package bc1.gream.domain.sell.repository;
 
+import static bc1.gream.domain.product.entity.QProduct.product;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bc1.gream.domain.gifticon.repository.GifticonRepository;
 import bc1.gream.domain.order.entity.Gifticon;
-import bc1.gream.domain.product.entity.Product;
-import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.sell.dto.response.SellPriceToQuantityResponseDto;
+import bc1.gream.domain.sell.entity.QSell;
 import bc1.gream.domain.sell.entity.Sell;
-import bc1.gream.domain.user.entity.User;
-import bc1.gream.domain.user.repository.UserRepository;
-import bc1.gream.global.config.QueryDslConfig;
-import bc1.gream.global.jpa.AuditingConfig;
+import bc1.gream.test.BaseDataRepositoryTest;
 import bc1.gream.test.SellTest;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({QueryDslConfig.class, AuditingConfig.class})
-class SellRepositoryCustomImplTest implements SellTest {
+class SellRepositoryCustomImplTest extends BaseDataRepositoryTest implements SellTest {
 
-    User user;
-    Product product;
-    Sell sell;
-
+    @Autowired
+    private JPAQueryFactory queryFactory;
     @Autowired
     private SellRepositoryCustomImpl sellRepositoryCustom;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private ProductRepository productRepository;
-    @Autowired
-    private GifticonRepository gifticonRepository;
     @Autowired
     private SellRepository sellRepository;
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(TEST_USER);
-        product = productRepository.save(TEST_PRODUCT);
-        Gifticon gifticon = gifticonRepository.save(Gifticon.builder()
-            .gifticonUrl(TEST_GIFTICON_URL)
-            .order(null)
-            .build()
-        );
-        sell = sellRepository.save(
-            Sell.builder()
-                .price(TEST_SELL_PRICE)
-                .deadlineAt(TEST_DEADLINE_AT)
-                .product(product)
-                .user(user)
-                .gifticon(gifticon)
+        setUpBaseDataRepositoryTest();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tearDownBaseDataRepositoryTest();
+    }
+
+    @Test
+    public void 상품_판매입찰_가격수량_조회() {
+        // GIVEN
+        Gifticon gifticon1 = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
                 .build()
         );
+        Sell samePriceBid = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(gifticon1)
+                .build()
+        );
+        Gifticon gifticon2 = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
+                .build()
+        );
+        Sell expensiveSellBid = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE + 100L)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(gifticon2)
+                .build()
+        );
+
+        // WHEN
+        Map<Long, Long> map = queryFactory
+            .select(QSell.sell.price, QSell.sell.count())
+            .from(QSell.sell)
+            .where(QSell.sell.product.eq(product))
+            .groupBy(QSell.sell.price)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(QSell.sell.price),
+                tuple -> tuple.get(QSell.sell.count())
+            ));
+
+        // THEN
+        assertEquals(2L, map.get(samePriceBid.getPrice()));
+        assertEquals(1L, map.get(expensiveSellBid.getPrice()));
+    }
+
+    @Test
+    public void 상품_판매입찰_가격수량_조회_페이징_가격오름차순() {
+        // GIVEN
+        Gifticon gifticon1 = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
+                .build()
+        );
+        Sell samePriceBid = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(gifticon1)
+                .build()
+        );
+        Gifticon gifticon2 = gifticonRepository.save(
+            Gifticon.builder()
+                .gifticonUrl(TEST_GIFTICON_URL)
+                .order(null)
+                .build()
+        );
+        Sell expensiveSellBid = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE + 100L)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(gifticon2)
+                .build()
+        );
+        Pageable pageable = PageRequest.of(1, 10);
+
+        // WHEN
+        Page<SellPriceToQuantityResponseDto> allPriceToQuantityOf = sellRepositoryCustom.findAllPriceToQuantityOf(savedProduct, pageable);
+
+        // THEN
+        assertEquals(samePriceBid.getPrice(), allPriceToQuantityOf.getContent().get(0).sellPrice());
+        assertEquals(2L, allPriceToQuantityOf.getContent().get(0).quantity());
+        assertEquals(expensiveSellBid.getPrice(),
+            allPriceToQuantityOf.getContent().get(allPriceToQuantityOf.getContent().size() - 1).sellPrice());
+        assertEquals(1L, allPriceToQuantityOf.getContent().get(allPriceToQuantityOf.getContent().size() - 1).quantity());
     }
 
     @Test
@@ -75,11 +147,11 @@ class SellRepositoryCustomImplTest implements SellTest {
         Pageable pageable = PageRequest.of(0, 10, Sort.by("id").ascending());
 
         // WHEN
-        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(product, pageable);
+        Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(savedProduct, pageable);
 
         // THEN
         boolean hasSellBid = allPricesOf.stream()
-            .anyMatch(s -> s.equals(sell));
+            .anyMatch(s -> s.equals(savedSell));
         assertTrue(hasSellBid);
     }
 
@@ -88,34 +160,34 @@ class SellRepositoryCustomImplTest implements SellTest {
     public void 상품_판매입찰_조회_페이징_기본순서_최근날짜순() {
         // GIVEN
         Pageable pageable = PageRequest.of(0, 10);
-        Gifticon pastGifticon = gifticonRepository.save(
+        Gifticon cheaperGifticon = gifticonRepository.save(
             Gifticon.builder()
                 .gifticonUrl(TEST_GIFTICON_URL)
                 .order(null)
                 .build()
         );
-        Sell pastSell = sellRepository.save(
+        Sell cheaperSellBid = sellRepository.save(
             Sell.builder()
-                .price(TEST_SELL_PRICE)
-                .deadlineAt(TEST_DEADLINE_AT)
-                .product(product)
-                .user(user)
-                .gifticon(pastGifticon)
+                .price(TEST_SELL_PRICE - 1000L)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(cheaperGifticon)
                 .build()
         );
-        Gifticon recentGifticon = gifticonRepository.save(
+        Gifticon moreExpensiveGifticon = gifticonRepository.save(
             Gifticon.builder()
                 .gifticonUrl(TEST_GIFTICON_URL)
                 .order(null)
                 .build()
         );
-        Sell recentSell = sellRepository.save(
+        Sell moreExpensiveSellBid = sellRepository.save(
             Sell.builder()
-                .price(TEST_SELL_PRICE)
-                .deadlineAt(TEST_DEADLINE_AT)
-                .product(product)
-                .user(user)
-                .gifticon(recentGifticon)
+                .price(TEST_SELL_PRICE + 1000L)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(moreExpensiveGifticon)
                 .build()
         );
 
@@ -123,7 +195,7 @@ class SellRepositoryCustomImplTest implements SellTest {
         Page<Sell> allPricesOf = sellRepositoryCustom.findAllPricesOf(TEST_PRODUCT, pageable);
 
         // THEN
-        assertEquals(recentSell, allPricesOf.getContent().get(0));
-        assertEquals(pastSell, allPricesOf.getContent().get(1));
+        assertEquals(cheaperSellBid, allPricesOf.getContent().get(0));
+        assertEquals(moreExpensiveSellBid, allPricesOf.getContent().get(allPricesOf.getContent().size() - 1));
     }
 }

--- a/src/test/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactoryTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/helper/SellQueryOrderFactoryTest.java
@@ -20,7 +20,7 @@ class SellQueryOrderFactoryTest {
         OrderSpecifier[] orders = SellQueryOrderFactory.getOrdersOf(pageable.getSort());
 
         // THEN
-        assertEquals(Order.DESC, orders[0].getOrder());
-        assertEquals(QSell.sell.createdAt, orders[0].getTarget());
+        assertEquals(Order.ASC, orders[0].getOrder());
+        assertEquals(QSell.sell.price, orders[0].getTarget());
     }
 }

--- a/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
+++ b/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
@@ -1,5 +1,6 @@
 package bc1.gream.test;
 
+import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
 import bc1.gream.domain.coupon.entity.Coupon;
 import bc1.gream.domain.coupon.repository.CouponRepository;
@@ -9,6 +10,7 @@ import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.repository.OrderRepository;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
@@ -33,6 +35,8 @@ public class BaseDataRepositoryTest implements ProductTest, UserTest, CouponTest
     protected Coupon savedCoupon;
     protected Order savedOrder;
     protected Gifticon savedGifticon;
+    protected Sell savedSell;
+    protected Buy savedBuy;
     @Autowired
     protected ProductRepository productRepository;
     @Autowired
@@ -76,16 +80,33 @@ public class BaseDataRepositoryTest implements ProductTest, UserTest, CouponTest
                 .gifticonUrl(TEST_GIFTICON_URL)
                 .order(savedOrder)
                 .build());
+        savedSell = sellRepository.save(
+            Sell.builder()
+                .price(TEST_SELL_PRICE)
+                .deadlineAt(SellTest.TEST_DEADLINE_AT)
+                .product(savedProduct)
+                .user(savedSeller)
+                .gifticon(savedGifticon)
+                .build()
+        );
+        savedBuy = buyRepository.save(
+            Buy.builder()
+                .price(TEST_BUY_PRICE)
+                .deadlineAt(BuyTest.TEST_DEADLINE_AT)
+                .user(savedBuyer)
+                .product(savedProduct)
+                .build()
+        );
     }
 
     /**
      * {@link DataJpaTest} 는 롤백이 default라 무관하지만, 만약 롤백을 false로 하셨다면, tearDown()에서 해당메서드를 호출하여 저장된 데이터를 삭제합니다.
      */
     protected void tearDownBaseDataRepositoryTest() {
-        orderRepository.deleteAllInBatch();
-        sellRepository.deleteAllInBatch();
         buyRepository.deleteAllInBatch();
+        sellRepository.deleteAllInBatch();
         gifticonRepository.deleteAllInBatch();
+        orderRepository.deleteAllInBatch();
         couponRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         productRepository.deleteAllInBatch();


### PR DESCRIPTION
## 개요
> 상품에 대한 입찰 조회 시, 수량과 정렬 기준을 변경

## 작업사항
-  판매 입찰은 키를 기준으로 오름차순 정렬하여 반환

- 구매 입찰은 키를 기준으로 내림차순 정렬하여 반환

## 관련 이슈
- close #119
