### PR TITLE
즉시 판매 쿠폰이 없을 경우 버그 수정

### DIFF
--- a/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
@@ -5,6 +5,7 @@ import bc1.gream.domain.buy.service.BuyService;
 import bc1.gream.domain.coupon.entity.Coupon;
 import bc1.gream.domain.coupon.entity.CouponStatus;
 import bc1.gream.domain.coupon.service.CouponService;
+import bc1.gream.domain.coupon.service.command.CouponCommandService;
 import bc1.gream.domain.gifticon.service.GifticonCommandService;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.mapper.OrderMapper;
@@ -25,15 +26,27 @@ public class SellNowProvider {
     private final CouponService couponService;
     private final OrderCommandService orderCommandService;
     private final GifticonCommandService gifticonCommandService;
+    private final CouponCommandService couponCommandService;
 
     @Transactional
     public SellNowResponseDto sellNowProduct(User user, SellNowRequestDto requestDto, Long productId) {
         // 해당상품과 가격에 대한 구매입찰
+
+        Order order;
+
         Buy buy = buyService.getRecentBuyBidOf(productId, requestDto.price());
         // 쿠폰 조회
         Coupon coupon = getCouponFrom(buy);
         // 새로운 주문
-        Order order = orderCommandService.saveOrderOfBuy(buy, user, coupon);
+        if (coupon != null) {
+            // 쿠폰이 존재할 때 쿠폰 상태 변경 및 쿠폰이 있는 order 저장 메소드로 이동
+            couponCommandService.changeCouponStatus(coupon, CouponStatus.ALREADY_USED);
+            order = orderCommandService.saveOrderOfBuy(buy, user, coupon);
+        } else {
+            // 쿠폰이 존재하지 않을 때 쿠폰이 없는 order 저장 메소드로 이동
+            order = orderCommandService.saveOrderOfBuyNotCoupon(buy, user);
+        }
+
         // 새로운 기프티콘 저장
         gifticonCommandService.saveGifticon(requestDto.gifticonUrl(), order);
         // 판매에 따른 사용자 포인트 충전

--- a/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellNowProvider.java
@@ -50,7 +50,7 @@ public class SellNowProvider {
         // 새로운 기프티콘 저장
         gifticonCommandService.saveGifticon(requestDto.gifticonUrl(), order);
         // 판매에 따른 사용자 포인트 충전
-        user.increasePoint(order.getFinalPrice());
+        user.increasePoint(order.getExpectedPrice());
 
         // 구매입찰 삭제
         buyService.delete(buy);


### PR DESCRIPTION
## 개요
- 구매 입찰에 쿠폰을 등록하지 않은 상태에서 즉시 판매 시 분기가 나뉘지 않음으로 따른 에러 수정
- 판매자 입장에서 판매 시 포인트 기대하는 가격으로 들어오게 수정


## 작업사항
- 즉시 판매 order 저장 로직에서 분기 생성
- 판매자가 즉시 판매시 판매하는 금액으로 포인드 들어가게 수정

## 관련 이슈
- close #161
