### PR TITLE
전체 상품 조회 시, 브랜드와 상품명을 Query Parameter로 입력받기

### DIFF
--- a/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
+++ b/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
@@ -1,6 +1,7 @@
-package bc1.gream.domain.order.entity;
+package bc1.gream.domain.gifticon.entity;
 
 import bc1.gream.domain.common.model.BaseEntity;
+import bc1.gream.domain.order.entity.Order;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/bc1/gream/domain/gifticon/mapper/GifticonMapper.java
+++ b/src/main/java/bc1/gream/domain/gifticon/mapper/GifticonMapper.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.gifticon.mapper;
 
 import bc1.gream.domain.buy.dto.response.BuyCheckOrderResponseDto;
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;

--- a/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepository.java
+++ b/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepository.java
@@ -1,6 +1,6 @@
 package bc1.gream.domain.gifticon.repository;
 
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GifticonRepository extends JpaRepository<Gifticon, Long>, GifticonRepositoryCustom {

--- a/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustom.java
@@ -1,6 +1,6 @@
 package bc1.gream.domain.gifticon.repository;
 
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.user.entity.User;
 import java.util.List;
 

--- a/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package bc1.gream.domain.gifticon.repository;
 
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.order.entity.QGifticon;
 import bc1.gream.domain.order.entity.QOrder;
 import bc1.gream.domain.user.entity.User;

--- a/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/gifticon/repository/GifticonRepositoryCustomImpl.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.gifticon.repository;
 
 import bc1.gream.domain.gifticon.entity.Gifticon;
-import bc1.gream.domain.order.entity.QGifticon;
+import bc1.gream.domain.gifticon.entity.QGifticon;
 import bc1.gream.domain.order.entity.QOrder;
 import bc1.gream.domain.user.entity.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/bc1/gream/domain/gifticon/service/GifticonCommandService.java
+++ b/src/main/java/bc1/gream/domain/gifticon/service/GifticonCommandService.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.gifticon.service;
 
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.order.entity.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/bc1/gream/domain/gifticon/service/GifticonQueryService.java
+++ b/src/main/java/bc1/gream/domain/gifticon/service/GifticonQueryService.java
@@ -2,9 +2,9 @@ package bc1.gream.domain.gifticon.service;
 
 
 import bc1.gream.domain.buy.dto.response.BuyCheckOrderResponseDto;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.mapper.GifticonMapper;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
+++ b/src/main/java/bc1/gream/domain/product/controller/ProductQueryController.java
@@ -46,8 +46,10 @@ public class ProductQueryController {
      */
     @GetMapping
     public RestResponse<List<ProductPreviewResponseDto>> findAll(
-        @RequestParam(required = false) ProductCondition productCondition
+        @RequestParam(required = false, defaultValue = "") String brand,
+        @RequestParam(required = false, defaultValue = "") String name
     ) {
+        ProductCondition productCondition = ProductCondition.builder().brand(brand).name(name).build();
         List<Product> products = productService.findAllBy(productCondition);
         List<ProductPreviewResponseDto> responseDtos = products.stream()
             .map(ProductMapper.INSTANCE::toPreviewResponseDto)

--- a/src/main/java/bc1/gream/domain/product/repository/helper/ProductQueryConditionFactory.java
+++ b/src/main/java/bc1/gream/domain/product/repository/helper/ProductQueryConditionFactory.java
@@ -17,7 +17,7 @@ public final class ProductQueryConditionFactory {
         if (name.isEmpty()) {
             return null;
         }
-        return product.name.eq(name);
+        return product.name.toLowerCase().containsIgnoreCase(name.toLowerCase());
     }
 
     public static BooleanExpression hasPriceRangeOf(Long startPrice, Long endPrice) {

--- a/src/main/java/bc1/gream/domain/sell/entity/Sell.java
+++ b/src/main/java/bc1/gream/domain/sell/entity/Sell.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.sell.entity;
 
 import bc1.gream.domain.common.model.BaseEntity;
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
@@ -1,7 +1,7 @@
 package bc1.gream.domain.sell.provider;
 
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.service.GifticonCommandService;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.sell.dto.request.SellBidRequestDto;
 import bc1.gream.domain.sell.dto.response.SellBidResponseDto;

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package bc1.gream.domain.sell.repository;
 
-import static bc1.gream.domain.order.entity.QGifticon.gifticon;
+import static bc1.gream.domain.gifticon.entity.QGifticon.gifticon;
 import static bc1.gream.domain.product.entity.QProduct.product;
 import static bc1.gream.domain.sell.entity.QSell.sell;
 import static bc1.gream.domain.user.entity.QUser.user;

--- a/src/test/java/bc1/gream/domain/product/controller/ProductQueryControllerIntegrationTest.java
+++ b/src/test/java/bc1/gream/domain/product/controller/ProductQueryControllerIntegrationTest.java
@@ -1,0 +1,48 @@
+package bc1.gream.domain.product.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bc1.gream.domain.product.dto.response.ProductPreviewResponseDto;
+import bc1.gream.global.common.RestResponse;
+import bc1.gream.test.BaseIntegrationTest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Disabled("통합테스트는 로컬에서만 실행합니다. 실행 시, SECRET KEY 에 대한 IntelliJ 환경변수를 설정해주어야 합니다.")
+class ProductQueryControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ProductQueryController productQueryController;
+
+    @BeforeEach
+    void setUp() {
+        setUpBaseIntegrationTest();
+    }
+
+    @AfterEach
+    void tearDown() {
+        tearDownBaseIntegrationTest();
+    }
+
+    @Test
+    @DisplayName("(조건에 따른) 상품 전체 목록 조회를 합니다.")
+    public void 조건_상품전체_목록조회() {
+        // GIVEN
+        String brand = "스타벅스";
+        String name = "아이스";
+
+        // WHEN
+        RestResponse<List<ProductPreviewResponseDto>> response = productQueryController.findAll(brand, name);
+
+        // THEN
+        List<ProductPreviewResponseDto> result = response.getData();
+        boolean hasIced = result.stream()
+            .anyMatch(r -> r.name().contains("아이스"));
+        assertTrue(hasIced);
+    }
+}

--- a/src/test/java/bc1/gream/domain/product/repository/helper/ProductQueryConditionFactoryTest.java
+++ b/src/test/java/bc1/gream/domain/product/repository/helper/ProductQueryConditionFactoryTest.java
@@ -32,7 +32,7 @@ class ProductQueryConditionFactoryTest implements ProductTest {
         BooleanExpression expression = ProductQueryConditionFactory.nameEquals(TEST_PRODUCT_NAME);
 
         // THEN
-        assertEquals(product.name.eq(TEST_PRODUCT_NAME), expression);
+        assertEquals(product.name.toLowerCase().containsIgnoreCase(TEST_PRODUCT_NAME), expression);
     }
     // WHEN
 

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -4,7 +4,7 @@ import static bc1.gream.domain.product.entity.QProduct.product;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.product.dto.response.SellPriceToQuantityResponseDto;
 import bc1.gream.domain.sell.entity.QSell;
 import bc1.gream.domain.sell.entity.Sell;

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryTest.java
@@ -2,8 +2,8 @@ package bc1.gream.domain.sell.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
 import bc1.gream.domain.sell.entity.Sell;

--- a/src/test/java/bc1/gream/domain/sell/service/SellNowProviderIntegrationTest.java
+++ b/src/test/java/bc1/gream/domain/sell/service/SellNowProviderIntegrationTest.java
@@ -40,7 +40,7 @@ class SellNowProviderIntegrationTest extends BaseIntegrationTest implements BuyT
                 .price(TEST_BUY_PRICE)
                 .deadlineAt(BuyTest.TEST_DEADLINE_AT)
                 .user(savedBuyer)
-                .product(savedProduct)
+                .product(savedIcedAmericano)
                 .couponId(savedCoupon.getId())
                 .build();
             buyRepository.save(buy);
@@ -53,7 +53,7 @@ class SellNowProviderIntegrationTest extends BaseIntegrationTest implements BuyT
         SellNowRequestDto requestDto = new SellNowRequestDto(TEST_BUY_PRICE, TEST_GIFTICON_URL);
 
         // WHEN
-        SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(savedSeller, requestDto, savedProduct.getId());
+        SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(savedSeller, requestDto, savedIcedAmericano.getId());
 
         // THEN
         System.out.println("responseDto = " + responseDto);
@@ -71,7 +71,7 @@ class SellNowProviderIntegrationTest extends BaseIntegrationTest implements BuyT
         List<SellNowResponseDto> sellNowResponseDtos = new ArrayList<>();
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
-                SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(savedSeller, requestDto, savedProduct.getId());
+                SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(savedSeller, requestDto, savedIcedAmericano.getId());
                 sellNowResponseDtos.add(responseDto);
 //                try{
 //                } catch (InterruptedException ex) {

--- a/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
+++ b/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
@@ -27,9 +27,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
-//@ActiveProfiles("test")
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import({QueryDslConfig.class, AuditingConfig.class})

--- a/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
+++ b/src/test/java/bc1/gream/test/BaseDataRepositoryTest.java
@@ -1,11 +1,16 @@
 package bc1.gream.test;
 
+import static bc1.gream.domain.coupon.entity.CouponStatus.AVAILABLE;
+import static bc1.gream.domain.coupon.entity.DiscountType.FIX;
+
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
 import bc1.gream.domain.coupon.entity.Coupon;
+import bc1.gream.domain.coupon.entity.CouponStatus;
+import bc1.gream.domain.coupon.entity.DiscountType;
 import bc1.gream.domain.coupon.repository.CouponRepository;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
-import bc1.gream.domain.order.entity.Gifticon;
 import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.repository.OrderRepository;
 import bc1.gream.domain.product.entity.Product;
@@ -16,14 +21,15 @@ import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.config.QueryDslConfig;
 import bc1.gream.global.jpa.AuditingConfig;
+import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
-@ActiveProfiles("test")
+//@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @Import({QueryDslConfig.class, AuditingConfig.class})
@@ -56,47 +62,14 @@ public class BaseDataRepositoryTest implements ProductTest, UserTest, CouponTest
      * Data Repository Test 환경을 위해 setUp()에서 해당메서드를 호출해주어야 합니다.
      */
     protected void setUpBaseDataRepositoryTest() {
-        savedProduct = productRepository.save(TEST_PRODUCT);
-        savedBuyer = userRepository.save(TEST_BUYER);
-        savedSeller = userRepository.save(TEST_SELLER);
-        savedCoupon = couponRepository.save(
-            Coupon.builder()
-                .name(TEST_COUPON_NAME)
-                .discountType(TEST_DISCOUNT_TYPE_WON)
-                .discount(TEST_DISCOUNT)
-                .status(TEST_COUPON_STATUS_AVAILABLE)
-                .user(savedBuyer)
-                .build());
-        savedOrder = orderRepository.save(
-            Order.builder()
-                .product(savedProduct)
-                .buyer(savedBuyer)
-                .seller(savedSeller)
-                .finalPrice(TEST_ORDER_FINAL_PRICE)
-                .expectedPrice(TEST_ORDER_EXPECTED_PRICE)
-                .build());
-        savedGifticon = gifticonRepository.save(
-            Gifticon.builder()
-                .gifticonUrl(TEST_GIFTICON_URL)
-                .order(savedOrder)
-                .build());
-        savedSell = sellRepository.save(
-            Sell.builder()
-                .price(TEST_SELL_PRICE)
-                .deadlineAt(SellTest.TEST_DEADLINE_AT)
-                .product(savedProduct)
-                .user(savedSeller)
-                .gifticon(savedGifticon)
-                .build()
-        );
-        savedBuy = buyRepository.save(
-            Buy.builder()
-                .price(TEST_BUY_PRICE)
-                .deadlineAt(BuyTest.TEST_DEADLINE_AT)
-                .user(savedBuyer)
-                .product(savedProduct)
-                .build()
-        );
+        savedProduct = saveProduct(TEST_PRODUCT);
+        savedBuyer = saveBuyer(TEST_BUYER);
+        savedSeller = saveSeller(TEST_SELLER);
+        savedCoupon = saveCouponOf(savedBuyer);
+        savedOrder = saveOrderOf(savedProduct, savedBuyer, savedSeller);
+        savedGifticon = saveGifticonOf(savedOrder);
+        savedSell = saveSellOf(savedProduct, savedSeller, savedGifticon);
+        savedBuy = saveBuyOf(savedBuyer, savedProduct);
     }
 
     /**
@@ -110,5 +83,92 @@ public class BaseDataRepositoryTest implements ProductTest, UserTest, CouponTest
         couponRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         productRepository.deleteAllInBatch();
+    }
+
+
+    private Buy saveBuyOf(User savedBuyer, Product savedProduct) {
+        Long TEST_BUY_PRICE = 4_500L;
+        LocalDateTime TEST_DEADLINE_AT = LocalDateTime.now().plusDays(7);
+        Buy buy = Buy.builder()
+            .price(TEST_BUY_PRICE)
+            .deadlineAt(TEST_DEADLINE_AT)
+            .user(savedBuyer)
+            .product(savedProduct)
+            .build();
+        ReflectionTestUtils.setField(buy, "id", 2000L);
+        return buyRepository.save(buy);
+    }
+
+    private Sell saveSellOf(Product savedProduct, User savedSeller, Gifticon savedGifticon) {
+        Long TEST_SELL_PRICE = 4_500L;
+        LocalDateTime TEST_DEADLINE_AT = LocalDateTime.now().plusDays(7);
+
+        Sell sell = Sell.builder()
+            .price(TEST_SELL_PRICE)
+            .deadlineAt(TEST_DEADLINE_AT)
+            .product(savedProduct)
+            .user(savedSeller)
+            .gifticon(savedGifticon)
+            .build();
+        ReflectionTestUtils.setField(sell, "id", 2000L);
+        return sellRepository.save(sell);
+    }
+
+    private Gifticon saveGifticonOf(Order savedOrder) {
+        String TEST_GIFTICON_URL = "images/images.png";
+
+        Gifticon gifticon = Gifticon.builder()
+            .gifticonUrl(TEST_GIFTICON_URL)
+            .order(savedOrder)
+            .build();
+        ReflectionTestUtils.setField(gifticon, "id", 2000L);
+        return gifticonRepository.save(gifticon);
+    }
+
+    private Order saveOrderOf(Product savedProduct, User savedBuyer, User savedSeller) {
+        Long TEST_ORDER_FINAL_PRICE = 4_000L;
+        Long TEST_ORDER_EXPECTED_PRICE = 4_500L;
+
+        Order order = Order.builder()
+            .product(savedProduct)
+            .buyer(savedBuyer)
+            .seller(savedSeller)
+            .finalPrice(TEST_ORDER_FINAL_PRICE)
+            .expectedPrice(TEST_ORDER_EXPECTED_PRICE)
+            .build();
+        ReflectionTestUtils.setField(order, "id", 2000L);
+        return orderRepository.save(order);
+    }
+
+    Coupon saveCouponOf(User savedBuyer) {
+        String TEST_COUPON_NAME = "TEST COUPON";
+        Long TEST_DISCOUNT = 500L;
+        DiscountType TEST_DISCOUNT_TYPE_WON = FIX;
+        CouponStatus TEST_COUPON_STATUS_AVAILABLE = AVAILABLE;
+
+        Coupon coupon = Coupon.builder()
+            .name(TEST_COUPON_NAME)
+            .discountType(TEST_DISCOUNT_TYPE_WON)
+            .discount(TEST_DISCOUNT)
+            .status(TEST_COUPON_STATUS_AVAILABLE)
+            .user(savedBuyer)
+            .build();
+        ReflectionTestUtils.setField(coupon, "id", 2000L);
+        return couponRepository.save(coupon);
+    }
+
+    private Product saveProduct(Product product) {
+        ReflectionTestUtils.setField(product, "id", 2000L);
+        return productRepository.save(product);
+    }
+
+    User saveBuyer(User user) {
+        ReflectionTestUtils.setField(user, "id", 2000L);
+        return userRepository.saveAndFlush(user);
+    }
+
+    User saveSeller(User user) {
+        ReflectionTestUtils.setField(user, "id", 2001L);
+        return userRepository.saveAndFlush(user);
     }
 }

--- a/src/test/java/bc1/gream/test/BaseIntegrationTest.java
+++ b/src/test/java/bc1/gream/test/BaseIntegrationTest.java
@@ -1,69 +1,183 @@
 package bc1.gream.test;
 
+import static bc1.gream.domain.coupon.entity.CouponStatus.AVAILABLE;
+import static bc1.gream.domain.coupon.entity.DiscountType.FIX;
+
+import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
+import bc1.gream.domain.coupon.entity.Coupon;
+import bc1.gream.domain.coupon.entity.CouponStatus;
+import bc1.gream.domain.coupon.entity.DiscountType;
+import bc1.gream.domain.coupon.repository.CouponRepository;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 import bc1.gream.domain.gifticon.repository.GifticonRepository;
+import bc1.gream.domain.order.entity.Order;
 import bc1.gream.domain.order.repository.OrderRepository;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.product.repository.ProductRepository;
+import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
-import bc1.gream.domain.coupon.entity.Coupon;
-import bc1.gream.domain.coupon.repository.CouponRepository;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.security.WithMockCustomUser;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
 @WithMockCustomUser
 @ActiveProfiles("test")
-@Rollback
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @Disabled("통합테스트는 로컬에서만 실행합니다. 실행 시, SECRET KEY 에 대한 IntelliJ 환경변수를 설정해주어야 합니다.")
 public class BaseIntegrationTest implements ProductTest, UserTest, CouponTest, BuyTest, SellTest, OrderTest, GifticonTest {
 
-    protected Product savedProduct;
+    protected Product savedIcedAmericano;
+    protected Product savedIcedCoffe;
+    protected Product savedCaffelatte;
     protected User savedSeller;
     protected User savedBuyer;
     protected Coupon savedCoupon;
+    protected Order savedOrder;
+    protected Gifticon savedGifticon;
+    protected Sell savedSell;
+    protected Buy savedBuy;
     @Autowired
-    private ProductRepository productRepository;
+    protected ProductRepository productRepository;
     @Autowired
-    private UserRepository userRepository;
+    protected UserRepository userRepository;
     @Autowired
-    private CouponRepository couponRepository;
+    protected CouponRepository couponRepository;
     @Autowired
-    private BuyRepository buyRepository;
+    protected BuyRepository buyRepository;
     @Autowired
-    private SellRepository sellRepository;
+    protected SellRepository sellRepository;
     @Autowired
-    private OrderRepository orderRepository;
+    protected OrderRepository orderRepository;
     @Autowired
-    private GifticonRepository gifticonRepository;
+    protected GifticonRepository gifticonRepository;
 
+    /**
+     * Integration Test 환경을 위해 setUp()에서 해당메서드를 호출해주어야 합니다.
+     */
     protected void setUpBaseIntegrationTest() {
-        savedProduct = productRepository.save(TEST_PRODUCT);
-        savedBuyer = userRepository.save(TEST_BUYER);
-        savedSeller = userRepository.save(TEST_SELLER);
-        Coupon couponOfBuyer = Coupon.builder()
+        savedIcedAmericano = saveProduct(TEST_PRODUCT);
+        savedCaffelatte = saveProduct(TEST_PRODUCT_SECOND);
+        savedIcedCoffe = saveProduct(TEST_PRODUCT_THIRD);
+
+        savedBuyer = saveBuyer(TEST_BUYER);
+        savedSeller = saveSeller(TEST_SELLER);
+
+        System.out.println("savedBuyer.getId() = " + savedBuyer.getId());
+        System.out.println("savedSeller.getId() = " + savedSeller.getId());
+
+        savedCoupon = saveCouponOf(savedBuyer);
+        savedOrder = saveOrderOf(savedIcedAmericano, savedBuyer, savedSeller);
+        savedGifticon = saveGifticonOf(savedOrder);
+        savedSell = saveSellOf(savedIcedAmericano, savedSeller, savedGifticon);
+        savedBuy = saveBuyOf(savedBuyer, savedIcedAmericano);
+    }
+
+    /**
+     * Integration Test 환경을 위해 tearDown()에서 해당메서드를 호출해주어야 합니다.
+     */
+    protected void tearDownBaseIntegrationTest() {
+        buyRepository.deleteAllInBatch();
+        sellRepository.deleteAllInBatch();
+        gifticonRepository.deleteAllInBatch();
+        orderRepository.deleteAllInBatch();
+        couponRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    private Buy saveBuyOf(User savedBuyer, Product savedProduct) {
+        Long TEST_BUY_PRICE = 4_500L;
+        LocalDateTime TEST_DEADLINE_AT = LocalDateTime.now().plusDays(7);
+        Buy buy = Buy.builder()
+            .price(TEST_BUY_PRICE)
+            .deadlineAt(TEST_DEADLINE_AT)
+            .user(savedBuyer)
+            .product(savedProduct)
+            .build();
+        ReflectionTestUtils.setField(buy, "id", 2000L);
+        return buyRepository.save(buy);
+    }
+
+    private Sell saveSellOf(Product savedProduct, User savedSeller, Gifticon savedGifticon) {
+        Long TEST_SELL_PRICE = 4_500L;
+        LocalDateTime TEST_DEADLINE_AT = LocalDateTime.now().plusDays(7);
+
+        Sell sell = Sell.builder()
+            .price(TEST_SELL_PRICE)
+            .deadlineAt(TEST_DEADLINE_AT)
+            .product(savedProduct)
+            .user(savedSeller)
+            .gifticon(savedGifticon)
+            .build();
+        ReflectionTestUtils.setField(sell, "id", 2000L);
+        return sellRepository.save(sell);
+    }
+
+    private Gifticon saveGifticonOf(Order savedOrder) {
+        String TEST_GIFTICON_URL = "images/images.png";
+
+        Gifticon gifticon = Gifticon.builder()
+            .gifticonUrl(TEST_GIFTICON_URL)
+            .order(savedOrder)
+            .build();
+        ReflectionTestUtils.setField(gifticon, "id", 2000L);
+        return gifticonRepository.save(gifticon);
+    }
+
+    private Order saveOrderOf(Product savedProduct, User savedBuyer, User savedSeller) {
+        Long TEST_ORDER_FINAL_PRICE = 4_000L;
+        Long TEST_ORDER_EXPECTED_PRICE = 4_500L;
+
+        Order order = Order.builder()
+            .product(savedProduct)
+            .buyer(savedBuyer)
+            .seller(savedSeller)
+            .finalPrice(TEST_ORDER_FINAL_PRICE)
+            .expectedPrice(TEST_ORDER_EXPECTED_PRICE)
+            .build();
+        ReflectionTestUtils.setField(order, "id", 2000L);
+        return orderRepository.save(order);
+    }
+
+    Coupon saveCouponOf(User savedBuyer) {
+        String TEST_COUPON_NAME = "TEST COUPON";
+        Long TEST_DISCOUNT = 500L;
+        DiscountType TEST_DISCOUNT_TYPE_WON = FIX;
+        CouponStatus TEST_COUPON_STATUS_AVAILABLE = AVAILABLE;
+
+        Coupon coupon = Coupon.builder()
             .name(TEST_COUPON_NAME)
             .discountType(TEST_DISCOUNT_TYPE_WON)
             .discount(TEST_DISCOUNT)
             .status(TEST_COUPON_STATUS_AVAILABLE)
             .user(savedBuyer)
             .build();
-        savedCoupon = couponRepository.save(couponOfBuyer);
+        ReflectionTestUtils.setField(coupon, "id", 2000L);
+        return couponRepository.save(coupon);
     }
 
-    protected void tearDownBaseIntegrationTest() {
-        sellRepository.deleteAllInBatch();
-        buyRepository.deleteAllInBatch();
-        gifticonRepository.deleteAllInBatch();
-        orderRepository.deleteAllInBatch();
-        couponRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
-        productRepository.deleteAllInBatch();
+    private Product saveProduct(Product product) {
+        ReflectionTestUtils.setField(product, "id", 2000L);
+        return productRepository.save(product);
+    }
+
+    User saveBuyer(User user) {
+        ReflectionTestUtils.setField(user, "id", 2000L);
+        return userRepository.saveAndFlush(user);
+    }
+
+    User saveSeller(User user) {
+        ReflectionTestUtils.setField(user, "id", 2001L);
+        return userRepository.saveAndFlush(user);
     }
 }

--- a/src/test/java/bc1/gream/test/GifticonTest.java
+++ b/src/test/java/bc1/gream/test/GifticonTest.java
@@ -1,6 +1,6 @@
 package bc1.gream.test;
 
-import bc1.gream.domain.order.entity.Gifticon;
+import bc1.gream.domain.gifticon.entity.Gifticon;
 
 public interface GifticonTest extends OrderTest {
 

--- a/src/test/java/bc1/gream/test/ProductTest.java
+++ b/src/test/java/bc1/gream/test/ProductTest.java
@@ -33,4 +33,19 @@ public interface ProductTest {
         .description(TEST_PRODUCT_SECOND_DESCRIPTION)
         .price(TEST_PRODUCT_SECOND_PRICE)
         .build();
+
+    Long TEST_PRODUCT_THIRD_ID = 3L;
+    String TEST_PRODUCT_THIRD_BRAND = "스타벅스";
+    String TEST_PRODUCT_THIRD_NAME = "아이스커피";
+    String TEST_PRODUCT_THIRD_IMAGE_URL = "bbeck_ice_coffee";
+    String TEST_PRODUCT_THIRD_DESCRIPTION = "얼어죽어도 아이스 커피가 좋아요";
+    Long TEST_PRODUCT_THIRD_PRICE = 3_000L;
+
+    Product TEST_PRODUCT_THIRD = Product.builder()
+        .brand(TEST_PRODUCT_THIRD_BRAND)
+        .name(TEST_PRODUCT_THIRD_NAME)
+        .imageUrl(TEST_PRODUCT_THIRD_IMAGE_URL)
+        .description(TEST_PRODUCT_THIRD_DESCRIPTION)
+        .price(TEST_PRODUCT_THIRD_PRICE)
+        .build();
 }


### PR DESCRIPTION
## 개요
> 전체 상품 조회 시, 브랜드와 상품명을 Query Parameter로 입력받기

## 작업사항
- 전체 상품 조회 시, 브랜드와 상품명을 Query Parameter로 입력받기
- Gifticon 엔티티 Order 패키지로부터 분리

## 관련 이슈
- close #165
