### PR TITLE
즉시 판매 및 판매 입찰에서 기프티콘 이미지를 받도록 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     // Retry
     implementation 'org.springframework.retry:spring-retry'
+    // AWS S3
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 
     /* DB */
     // MySQL

--- a/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
+++ b/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
@@ -26,7 +26,7 @@ public class Gifticon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "gifticon_url")
+    @Column(name = "gifticon_url", columnDefinition = "TEXT")
     private String gifticonUrl;
 
     @OneToOne(cascade = CascadeType.PERSIST)

--- a/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
+++ b/src/main/java/bc1/gream/domain/gifticon/entity/Gifticon.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -26,7 +27,8 @@ public class Gifticon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "gifticon_url", columnDefinition = "TEXT")
+    @Lob
+    @Column(name = "gifticon_url")
     private String gifticonUrl;
 
     @OneToOne(cascade = CascadeType.PERSIST)

--- a/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
+++ b/src/main/java/bc1/gream/domain/sell/controller/SellBidController.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,7 +38,7 @@ public class SellBidController {
     @Operation(summary = "판매입찰 체결 요청", description = "판매자의 상품에 대한 판매입찰 체결요청을 처리합니다.")
     public RestResponse<SellBidResponseDto> createSellBid(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @Valid @RequestBody SellBidRequestDto requestDto,
+        @Valid SellBidRequestDto requestDto,
         @PathVariable Long productId
     ) {
         Product product = productValidator.validateBy(productId);

--- a/src/main/java/bc1/gream/domain/sell/controller/SellNowController.java
+++ b/src/main/java/bc1/gream/domain/sell/controller/SellNowController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,7 +34,7 @@ public class SellNowController {
     public RestResponse<SellNowResponseDto> sellNowProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable Long productId,
-        @Valid @RequestBody SellNowRequestDto requestDto
+        @Valid SellNowRequestDto requestDto
     ) {
         SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(userDetails.getUser(), requestDto, productId);
         return RestResponse.success(responseDto);

--- a/src/main/java/bc1/gream/domain/sell/dto/request/SellBidRequestDto.java
+++ b/src/main/java/bc1/gream/domain/sell/dto/request/SellBidRequestDto.java
@@ -1,16 +1,16 @@
 package bc1.gream.domain.sell.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
 
 @Builder
 public record SellBidRequestDto(
     @NotNull(message = "가격 필드는 비울 수 없습니다.")
     Long price,
     Integer period,
-    @NotBlank(message = "기프티콘을 업로드해 주세요")
-    String gifticonUrl
+    @NotNull(message = "기프티콘을 업로드해 주세요")
+    MultipartFile file
 ) {
 
 }

--- a/src/main/java/bc1/gream/domain/sell/dto/request/SellNowRequestDto.java
+++ b/src/main/java/bc1/gream/domain/sell/dto/request/SellNowRequestDto.java
@@ -1,13 +1,13 @@
 package bc1.gream.domain.sell.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
 
 public record SellNowRequestDto(
     @NotNull(message = "가격 필드는 비울 수 없습니다.")
     Long price,
-    @NotBlank(message = "기프티콘을 업로드해 주세요")
-    String gifticonUrl
+    @NotNull(message = "기프티콘을 업로드해 주세요")
+    MultipartFile file
 ) {
 
 }

--- a/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -31,6 +32,7 @@ public class SellBidProvider {
     private final SellService sellService;
     private final S3ImageService s3ImageService;
 
+    @Transactional
     public SellBidResponseDto createSellBid(User seller, SellBidRequestDto requestDto, Product product) {
 
         // 기프티콘 이미지 S3 저장

--- a/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
+++ b/src/main/java/bc1/gream/domain/sell/provider/SellBidProvider.java
@@ -13,12 +13,15 @@ import bc1.gream.domain.sell.service.SellService;
 import bc1.gream.domain.sell.service.helper.deadline.Deadline;
 import bc1.gream.domain.sell.service.helper.deadline.DeadlineCalculator;
 import bc1.gream.domain.user.entity.User;
+import bc1.gream.infra.s3.S3ImageService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SellBidProvider {
@@ -26,10 +29,15 @@ public class SellBidProvider {
     private final SellRepository sellRepository;
     private final GifticonCommandService gifticonCommandService;
     private final SellService sellService;
+    private final S3ImageService s3ImageService;
 
     public SellBidResponseDto createSellBid(User seller, SellBidRequestDto requestDto, Product product) {
+
+        // 기프티콘 이미지 S3 저장
+        String url = s3ImageService.getUrlAfterUpload(requestDto.file());
+
         // 기프티콘 생성, 저장
-        Gifticon gifticon = gifticonCommandService.saveGifticon(requestDto.gifticonUrl(), null);
+        Gifticon gifticon = gifticonCommandService.saveGifticon(url, null);
         // 마감기한 지정 : LocalTime.Max :: 23시 59분 59초
         Integer period = Deadline.getPeriod(requestDto.period());
         LocalDateTime deadlineAt = DeadlineCalculator.calculateDeadlineBy(LocalDate.now(), LocalTime.MAX,

--- a/src/main/java/bc1/gream/global/common/ResultCase.java
+++ b/src/main/java/bc1/gream/global/common/ResultCase.java
@@ -67,7 +67,11 @@ public enum ResultCase {
     COUPON_ALREADY_IN_USED(HttpStatus.NOT_FOUND, 6002, "해당 쿠폰은 이미 사용중입니다."),
     COUPON_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, 6003, "해당 쿠폰 종류는 존재하지 않는 종류입니다."),
     COUPON_TYPE_INVALID_RATE(HttpStatus.CONFLICT, 6004, "올바른 형식의 고정할인가를 입력해주세요."),
-    COUPON_TYPE_INVALID_FIXED(HttpStatus.CONFLICT, 6005, "올바른 형식의 할인율을 입력해주세요.");
+    COUPON_TYPE_INVALID_FIXED(HttpStatus.CONFLICT, 6005, "올바른 형식의 할인율을 입력해주세요."),
+
+    // S3 7000번대
+    IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 7000, "이미지 업로드에 실패했습니다.");
+
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;

--- a/src/main/java/bc1/gream/infra/s3/S3Config.java
+++ b/src/main/java/bc1/gream/infra/s3/S3Config.java
@@ -1,0 +1,28 @@
+package bc1.gream.infra.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+            .build();
+    }
+}

--- a/src/main/java/bc1/gream/infra/s3/S3ImageService.java
+++ b/src/main/java/bc1/gream/infra/s3/S3ImageService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j(topic = "s3 image upload")
@@ -24,6 +25,7 @@ public class S3ImageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Transactional
     public String getUrlAfterUpload(MultipartFile image) {
 
         String originalName = image.getOriginalFilename();

--- a/src/main/java/bc1/gream/infra/s3/S3ImageService.java
+++ b/src/main/java/bc1/gream/infra/s3/S3ImageService.java
@@ -1,0 +1,62 @@
+package bc1.gream.infra.s3;
+
+import bc1.gream.global.common.ResultCase;
+import bc1.gream.global.exception.GlobalException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j(topic = "s3 image upload")
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+    private static final String gifticonDirectoryName = "gifticon/";
+    private final AmazonS3 amazonS3;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String getUrlAfterUpload(MultipartFile image) {
+
+        String originalName = image.getOriginalFilename();
+        String randomImageName = getRandomImageName(originalName);
+        log.info("s3 upload name : {}", randomImageName);
+
+        try {
+            PutObjectRequest request = new PutObjectRequest(
+                bucketName,
+                randomImageName,
+                image.getInputStream(),
+                createObjectMetadata(originalName)
+            )
+                .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(request);
+        } catch (IOException e) {
+            throw new GlobalException(ResultCase.SYSTEM_ERROR);
+        }
+
+        String url = amazonS3.getUrl(bucketName, randomImageName).toString();
+        log.info("s3 url : {}", url);
+        return url;
+    }
+
+    private String getRandomImageName(String originalName) {
+        String random = UUID.randomUUID().toString();
+        return gifticonDirectoryName + random + '-' + originalName;
+    }
+
+    private ObjectMetadata createObjectMetadata(String originalName) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        String ext = originalName.substring(originalName.lastIndexOf("."));
+        metadata.setContentType("image/" + ext);
+        return metadata;
+    }
+}

--- a/src/main/java/bc1/gream/infra/s3/S3ImageService.java
+++ b/src/main/java/bc1/gream/infra/s3/S3ImageService.java
@@ -40,7 +40,7 @@ public class S3ImageService {
                 .withCannedAcl(CannedAccessControlList.PublicRead);
             amazonS3.putObject(request);
         } catch (IOException e) {
-            throw new GlobalException(ResultCase.SYSTEM_ERROR);
+            throw new GlobalException(ResultCase.IMAGE_UPLOAD_FAIL);
         }
 
         String url = amazonS3.getUrl(bucketName, randomImageName).toString();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,13 @@ server:
     access-log: # ACESS 에 대한 로깅
       enabled: true
       pattern: "%{yyyy-MM-dd HH:mm:ss}t\\t%s\\t%r\\t%{User-Agent}i\\t%{Referer}i\\t%a\\t%b"
+# s3
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+    stack.auto: false
+    region.static: ${REGION}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_ACCESS_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   # JPA
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         auto_quote_keyword: true # 예약어 사용가능

--- a/src/test/java/bc1/gream/domain/sell/service/SellBidProviderTest.java
+++ b/src/test/java/bc1/gream/domain/sell/service/SellBidProviderTest.java
@@ -16,6 +16,7 @@ import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.provider.SellBidProvider;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;
+import bc1.gream.infra.s3.S3ImageService;
 import bc1.gream.test.GifticonTest;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,8 @@ class SellBidProviderTest implements GifticonTest {
     GifticonCommandService gifticonCommandService;
     @Mock
     SellService sellService;
+    @Mock
+    S3ImageService s3ImageService;
 
     @InjectMocks
     SellBidProvider sellBidProvider;
@@ -47,10 +50,11 @@ class SellBidProviderTest implements GifticonTest {
 
         SellBidRequestDto requestDto = SellBidRequestDto.builder()
             .price(TEST_SELL_PRICE)
-            .gifticonUrl(fileResource.getURL().getPath())
+            .file(TEST_GIFTICON_FILE)
             .build();
 
-        given(gifticonCommandService.saveGifticon(requestDto.gifticonUrl(), null)).willReturn(TEST_GIFTICON);
+        given(s3ImageService.getUrlAfterUpload(requestDto.file())).willReturn(TEST_S3_IMAGE_URL);
+        given(gifticonCommandService.saveGifticon(TEST_S3_IMAGE_URL, null)).willReturn(TEST_GIFTICON);
         given(sellRepository.save(any(Sell.class))).willReturn(TEST_SELL);
 
         // when

--- a/src/test/java/bc1/gream/domain/sell/service/SellNowProviderIntegrationTest.java
+++ b/src/test/java/bc1/gream/domain/sell/service/SellNowProviderIntegrationTest.java
@@ -50,7 +50,7 @@ class SellNowProviderIntegrationTest extends BaseIntegrationTest implements BuyT
     @Test
     public void 즉시판매조회() {
         // GIVEN
-        SellNowRequestDto requestDto = new SellNowRequestDto(TEST_BUY_PRICE, TEST_GIFTICON_URL);
+        SellNowRequestDto requestDto = new SellNowRequestDto(TEST_BUY_PRICE, TEST_GIFTICON_FILE);
 
         // WHEN
         SellNowResponseDto responseDto = sellNowProvider.sellNowProduct(savedSeller, requestDto, savedIcedAmericano.getId());
@@ -65,7 +65,7 @@ class SellNowProviderIntegrationTest extends BaseIntegrationTest implements BuyT
         int threadCount = 100;
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-        SellNowRequestDto requestDto = new SellNowRequestDto(TEST_BUY_PRICE, TEST_GIFTICON_URL);
+        SellNowRequestDto requestDto = new SellNowRequestDto(TEST_BUY_PRICE, TEST_GIFTICON_FILE);
 
         // WHEN
         List<SellNowResponseDto> sellNowResponseDtos = new ArrayList<>();

--- a/src/test/java/bc1/gream/test/GifticonTest.java
+++ b/src/test/java/bc1/gream/test/GifticonTest.java
@@ -1,12 +1,16 @@
 package bc1.gream.test;
 
 import bc1.gream.domain.gifticon.entity.Gifticon;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface GifticonTest extends OrderTest {
 
     Long TEST_GIFTICON_ID = 1L;
 
     String TEST_GIFTICON_URL = "images/images.png";
+    MultipartFile TEST_GIFTICON_FILE = new MockMultipartFile("file", "image.png", "image/png", "content".getBytes());
+    String TEST_S3_IMAGE_URL = "https://cataas.com/cat";
 
     Gifticon TEST_GIFTICON_END = Gifticon.builder()
         .gifticonUrl(TEST_GIFTICON_URL)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,11 +6,11 @@ spring:
   # JPA
   jpa:
     database: h2
-    generate-ddl: off
+    generate-ddl: on
     defer-datasource-initialization: true
     properties:
       hibernate:
-        ddl-auto: none
+        ddl-auto: create
         auto_quote_keyword: true # 예약어 사용가능
         globally_quoted_identifiers: true # 예약어 사용가능
         show_sql: true # sql 로깅


### PR DESCRIPTION
## 개요
즉시 판매 및 판매 입찰에서 기프티콘 이미지를 받도록 수정 

## 작업사항
- 기프티콘 엔티티의 url 필드의 타입을 TINYTEXT 에서 TEXT 로 수정 
- S3 설정 추가 
- S3 서비스 추가 
- 즉시 판매 및 판매 입찰 API의 요청 DTO가 이미지를 받도록 수정
- 위의 API가 Multipart/form-data 로 받도록 수정 
- 해당 프로바이더가 S3 서비스를 이용하도록 수정 
- application.yml 파일에서 ddl-auto 설정을 none 으로 변경 

## 관련 이슈
- close #180 
