### PR TITLE
Feat/delete image if rollback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation 'org.springframework.retry:spring-retry'
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+    // VAVR
+    implementation 'io.vavr:vavr:0.10.4'
 
     /* DB */
     // MySQL

--- a/src/main/java/bc1/gream/global/common/ResultCase.java
+++ b/src/main/java/bc1/gream/global/common/ResultCase.java
@@ -27,12 +27,15 @@ public enum ResultCase {
     // 만료된 리프레쉬 토큰 401
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1006, "만료된 Refresh Token"),
     NOT_ENOUGH_POINT(HttpStatus.FORBIDDEN, 1007, "유저의 포인트가 부족합니다"),
+    USER_ADD_POINT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 1008, "서버 내부 장애로 인해 유저의 포인트 충전 요청을 수행하지 못 하였습니다."),
 
     // 상품 2000번대
     // 검색 결과 없음 404
     SEARCH_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "검색 결과가 없습니다."),
     // 존재하지 않는 상품 404
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, 2001, "해당 상품은 존재하지 않습니다."),
+    GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 2002, "해당 id의 기프티콘은 존재하지 않습니다."),
+    GIFTICON_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 2003, "서버 내부 장애로 인해 기프티콘 저장요청을 수행하지 못 하였습니다."),
 
     // 구매 3000번대
     // 구매 요청 대상 상품이 이미 판매되었음 409
@@ -45,9 +48,10 @@ public enum ResultCase {
     // 판매 4000번대
     // 판매 요청 대상 상품이 이미 구매되었음 409
     SELL_PRODUCT_SOLD_OUT(HttpStatus.CONFLICT, 4000, "판매 요청 대상 상품이 이미 구매되었습니다."),
+    SELL_BID_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 4001, "서버 내부 장애로 인해 판매입찰 데이터 삭제요청을 수행하지 못 하였습니다."),
     // 판매 요청에 대상 상품이 존재하지 않음 404
     SELL_BID_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "해당 판매 입찰 건은 존재하지 않습니다."),
-    GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 4002, "해당 id의 기프티콘은 존재하지 않습니다."),
+    SELL_BID_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, 4002, "서버 내부 장애로 인해 판매입찰 생성요청을 수행하지 못 하였습니다."),
     // 입찰 마감 기한 초과 409
 
     // 글로벌 5000번대

--- a/src/main/java/bc1/gream/global/exception/S3ExceptionHandlingUtil.java
+++ b/src/main/java/bc1/gream/global/exception/S3ExceptionHandlingUtil.java
@@ -1,0 +1,61 @@
+package bc1.gream.global.exception;
+
+import bc1.gream.global.common.ResultCase;
+import bc1.gream.infra.s3.S3ImageService;
+import io.vavr.control.Try;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+public class S3ExceptionHandlingUtil {
+
+    /**
+     * 타겟함수에 대해 실행, 성공 시 반환값을 반환하고, 실패 시 s3 이미지를 삭제한 뒤 예외처리합니다.
+     *
+     * @param targetFunction Function<T, R> 타겟함수
+     * @param s3ImageService s3 이미지 서비스
+     * @param imageUrl       이미지 URL
+     * @param resultCase     예외케이스
+     * @param <T>            타켓함수의 제너릭 클래스
+     * @return 타켓함수의 반환값
+     * @author 임지훈
+     */
+    public static <T> T tryWithS3Cleanup(ThrowingFunction<T> targetFunction, S3ImageService s3ImageService, String imageUrl,
+        ResultCase resultCase) {
+        return Try.of(targetFunction::apply)
+            .onFailure(ex -> handleException(ex, s3ImageService, imageUrl))
+            .getOrElseThrow(() -> new GlobalException(resultCase));
+    }
+
+    /**
+     * 타겟함수에 대해 실행, 실패 시 s3 이미지를 삭제한 뒤 예외처리합니다.
+     *
+     * @param targetRunnable Runnable 타겟함수
+     * @param s3ImageService s3 이미지 서비스
+     * @param imageUrl       이미지 URL
+     * @param resultCase     예외케이스
+     */
+    public static void tryWithS3Cleanup(ThrowingRunnable targetRunnable, S3ImageService s3ImageService, String imageUrl,
+        ResultCase resultCase) {
+        Try.run(targetRunnable::run)
+            .onFailure(ex -> handleException(ex, s3ImageService, imageUrl))
+            .getOrElseThrow(() -> new GlobalException(resultCase));
+    }
+
+    private static void handleException(Throwable ex, S3ImageService s3ImageService, String imageUrl) {
+        if (ex instanceof IllegalArgumentException || ex instanceof OptimisticLockingFailureException) {
+            // s3ImageService.delete(imageUrl);
+        }
+    }
+
+    @FunctionalInterface
+    public interface ThrowingFunction<T> {
+
+        T apply() throws Exception;
+    }
+
+
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+
+        void run() throws Exception;
+    }
+}


### PR DESCRIPTION
## 개요
> **롤백 처리 시, 이미지 삭제함수를 함수형으로 구현**

## 작업사항
> 아직 S3 이미지 삭제 처리방안이 떠오르지 않아 도와주시면 감사하겠습니다 ㅎㅎ
1. 이미지 저장 시, UUID.random() 값을 저장하여 이미지 삭제를 어떻게 처리하는지 모르겠음
	> 포스트를 보아도 방법이 각자 다 달라서,,
2. 트랜잭션 롤백 처리 시, 이미지 삭제 요청도 하게 해놓았음
3. 이게 효율적인 것인지는 모르겠음
	장점 :: 어느 하나라도 롤백되면 이미지 삭제처리 가능
	단점 :: (그럴리없겠지만)여러 곳에서 에러 나면 삭제 요청을 여러번요청
4. 기프티콘 예외처리를 2000번대에서 상품과 같이 하고 있는데 이게 맞는지 ??
5. 가장 현실적인 이미지 삭제안은 해당 링크가 제일 현실적이라고 보임  https://velog.io/@sontulip/s3-rollback-problem
	> 다만 현재 처리한 방식도 틀린 것인가? 에 대해서는 의문임

## 관련 이슈
- 
