### PR TITLE
refactor : 빌드시 redis에서 엔티티의 레포지토리에 대해 식별할수 없다는 info 삭제

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,8 @@ spring:
     redis:
       host: ${REDIS_URL}
       port: 6379
+      repositories:
+        enabled: false
 # JWT
 jwt:
   secret:


### PR DESCRIPTION
## 개요
빌드시 redis에서 엔티티의 레포지토리에 대해 식별할수 없다는 info 삭제

## 작업사항
- 빌드시 redis에서 엔티티의 레포지토리에 대해 식별할수 없다는 info 삭제

## 관련 이슈
- 
