### PR TITLE
@Transactional(readOnly = true) 에 따라 Multi DataSource 매핑

### DIFF
--- a/src/main/java/bc1/gream/global/config/datasource/DataSourceType.java
+++ b/src/main/java/bc1/gream/global/config/datasource/DataSourceType.java
@@ -1,0 +1,6 @@
+package bc1.gream.global.config.datasource;
+
+public enum DataSourceType {
+    READ_WRITE,
+    READ_ONLY
+}

--- a/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSource.java
+++ b/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSource.java
@@ -1,0 +1,19 @@
+package bc1.gream.global.config.datasource;
+
+
+import jakarta.annotation.Nullable;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class TransactionRoutingDataSource
+    extends AbstractRoutingDataSource {
+
+    @Nullable
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager
+            .isCurrentTransactionReadOnly() ?
+            DataSourceType.READ_ONLY :
+            DataSourceType.READ_WRITE;
+    }
+}

--- a/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfig.java
+++ b/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfig.java
@@ -3,7 +3,6 @@ package bc1.gream.global.config.datasource;
 import com.zaxxer.hikari.HikariDataSource;
 import jakarta.persistence.EntityManagerFactory;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,10 +38,10 @@ public class TransactionRoutingDataSourceConfig {
         @Qualifier("secondaryDataSource") DataSource secondary) throws SQLException {
         TransactionRoutingDataSource routingDataSource = new TransactionRoutingDataSource();
 
-        Map<Object, Object> dataSourceMap = new HashMap<>();
-
-        dataSourceMap.put(DataSourceType.READ_WRITE, primary);
-        dataSourceMap.put(DataSourceType.READ_ONLY, secondary);
+        Map<Object, Object> dataSourceMap = Map.of(
+            DataSourceType.READ_WRITE, primary,
+            DataSourceType.READ_ONLY, secondary
+        );
 
         routingDataSource.setTargetDataSources(dataSourceMap);
         routingDataSource.setDefaultTargetDataSource(primary);

--- a/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfig.java
+++ b/src/main/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfig.java
@@ -1,0 +1,67 @@
+package bc1.gream.global.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class TransactionRoutingDataSourceConfig {
+
+    @ConfigurationProperties(prefix = "spring.datasource.hikari.primary")
+    @Bean
+    public DataSource primaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @ConfigurationProperties(prefix = "spring.datasource.hikari.secondary")
+    @Bean
+    public DataSource secondaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @DependsOn({"primaryDataSource", "secondaryDataSource"})
+    @Bean
+    public DataSource routingDataSource(
+        @Qualifier("primaryDataSource") DataSource primary,
+        @Qualifier("secondaryDataSource") DataSource secondary) throws SQLException {
+        TransactionRoutingDataSource routingDataSource = new TransactionRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put(DataSourceType.READ_WRITE, primary);
+        dataSourceMap.put(DataSourceType.READ_ONLY, secondary);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(primary);
+
+        return routingDataSource;
+    }
+
+    @DependsOn({"routingDataSource"})
+    @Primary
+    @Bean
+    public DataSource dataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,17 @@ spring:
     active: prod
   # DATASOURCE
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_URL}/gream
-    username: ${DB_ID}
-    password: ${DB_PASSWORD}
+    hikari:
+      primary:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        jdbc-url: jdbc:mysql://${DB_URL}/gream
+        username: ${DB_ID}
+        password: ${DB_PASSWORD}
+      secondary:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        jdbc-url: jdbc:mysql://${DB_READ_ONLY_URL}/gream
+        username: ${DB_ID}
+        password: ${DB_PASSWORD}
   # JPA
   jpa:
     hibernate:

--- a/src/test/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfigTest.java
+++ b/src/test/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfigTest.java
@@ -1,8 +1,11 @@
 package bc1.gream.global.config.datasource;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jakarta.persistence.EntityManager;
 import java.sql.SQLException;
 import javax.sql.DataSource;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Disabled("application.yml의 DB_URL과 DB_READ_ONLY_URL 를 매핑하여 테스트해야합니다.")
 class TransactionRoutingDataSourceConfigTest {
 
     @Autowired
@@ -22,17 +26,15 @@ class TransactionRoutingDataSourceConfigTest {
     @DisplayName("Read-Write Transaction에 대해 Primary DB 커넥션을 사용합니다.")
     @Transactional
     void primary_데이터소스_LazyConnectionDataSourceProxy() throws SQLException {
-        // Perform database operations that require read-write transaction
-        // This method will use the primary data source
-        System.out.println("dataSource.getConnection().getMetaData().getURL() = " + dataSource.getConnection().getMetaData().getURL());
+        // THEN
+        assertTrue(dataSource.getConnection().getMetaData().getURL().contains("bc1-gream-database-01"));
     }
 
     @Test
     @DisplayName("Read-Only Transaction에 대해 Secondary DB 커넥션을 사용합니다.")
     @Transactional(readOnly = true)
     void secondary_데이터소스_LazyConnectionDataSourceProxy() throws SQLException {
-        // Perform database operations that only require read-only access
-        // This method will use the secondary data source
-        System.out.println("dataSource.getConnection().getMetaData().getURL() = " + dataSource.getConnection().getMetaData().getURL());
+        // THEN
+        assertTrue(dataSource.getConnection().getMetaData().getURL().contains("bc1-gream-read-only"));
     }
 }

--- a/src/test/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfigTest.java
+++ b/src/test/java/bc1/gream/global/config/datasource/TransactionRoutingDataSourceConfigTest.java
@@ -1,0 +1,38 @@
+package bc1.gream.global.config.datasource;
+
+import jakarta.persistence.EntityManager;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class TransactionRoutingDataSourceConfigTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("Read-Write Transaction에 대해 Primary DB 커넥션을 사용합니다.")
+    @Transactional
+    void primary_데이터소스_LazyConnectionDataSourceProxy() throws SQLException {
+        // Perform database operations that require read-write transaction
+        // This method will use the primary data source
+        System.out.println("dataSource.getConnection().getMetaData().getURL() = " + dataSource.getConnection().getMetaData().getURL());
+    }
+
+    @Test
+    @DisplayName("Read-Only Transaction에 대해 Secondary DB 커넥션을 사용합니다.")
+    @Transactional(readOnly = true)
+    void secondary_데이터소스_LazyConnectionDataSourceProxy() throws SQLException {
+        // Perform database operations that only require read-only access
+        // This method will use the secondary data source
+        System.out.println("dataSource.getConnection().getMetaData().getURL() = " + dataSource.getConnection().getMetaData().getURL());
+    }
+}


### PR DESCRIPTION
## 개요
> @Transactional(readOnly = true) 에 따라 읽기 전용 RDS 매핑하였습니다.

## 작업사항
- application.yml 에서 primary datasource, secondary datasource 분리
- AbstractRoutingDataSource 를 통해 readOnly 트랜잭션인지 구분
- Primary, Secondary Datasource 매핑을 위한 TransactionRoutingDataSourceConfig 정의

## 관련 이슈
- close #206 
