### PR TITLE
토스 API 호출 핸들러를 EventPublisher & Callback 을 통해 분리

### DIFF
--- a/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentEventListener.java
+++ b/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentEventListener.java
@@ -8,6 +8,7 @@ import net.minidev.json.JSONObject;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.client.RestTemplate;
@@ -15,6 +16,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class TossPaymentEventListener {
 
+    @Async
     @TransactionalEventListener
     public void handleTossPaymentSuccess(TossPaymentSuccessEvent event) {
         RestTemplate rest = new RestTemplate();

--- a/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentEventListener.java
+++ b/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentEventListener.java
@@ -1,0 +1,42 @@
+package bc1.gream.domain.payment.toss.service.event;
+
+import bc1.gream.domain.payment.toss.dto.response.TossPaymentSuccessResponseDto;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import net.minidev.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class TossPaymentEventListener {
+
+    @TransactionalEventListener
+    public void handleTossPaymentSuccess(TossPaymentSuccessEvent event) {
+        RestTemplate rest = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        String testSecretApiKey = event.getTestSecretApiKey() + ":";
+        String encodedAuth = new String(Base64.getEncoder().encode(testSecretApiKey.getBytes(StandardCharsets.UTF_8)));
+        headers.setBasicAuth(encodedAuth);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+        JSONObject param = new JSONObject();
+        param.put("orderId", event.getOrderId());
+        param.put("amount", event.getAmount());
+
+        TossPaymentSuccessResponseDto responseDto = rest.postForObject(
+            event.getSuccessUrl() + event.getPaymentKey(),
+            new HttpEntity<>(param, headers),
+            TossPaymentSuccessResponseDto.class
+        );
+
+        // Use the functional interface to pass the result back to TossPaymentController
+        event.getCallback().handle(responseDto);
+    }
+}

--- a/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentSuccessCallback.java
+++ b/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentSuccessCallback.java
@@ -1,0 +1,9 @@
+package bc1.gream.domain.payment.toss.service.event;
+
+import bc1.gream.domain.payment.toss.dto.response.TossPaymentSuccessResponseDto;
+
+@FunctionalInterface
+public interface TossPaymentSuccessCallback {
+
+    void handle(TossPaymentSuccessResponseDto responseDto);
+}

--- a/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentSuccessEvent.java
+++ b/src/main/java/bc1/gream/domain/payment/toss/service/event/TossPaymentSuccessEvent.java
@@ -1,0 +1,27 @@
+package bc1.gream.domain.payment.toss.service.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class TossPaymentSuccessEvent extends ApplicationEvent {
+
+    private final String paymentKey;
+    private final Long orderId;
+    private final Long amount;
+    private final String successUrl;
+    private final String testSecretApiKey;
+
+    private final TossPaymentSuccessCallback callback;
+
+    public TossPaymentSuccessEvent(Object source, String paymentKey, Long orderId, Long amount, String successUrl, String testSecretApiKey,
+        TossPaymentSuccessCallback callback) {
+        super(source);
+        this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.amount = amount;
+        this.successUrl = successUrl;
+        this.testSecretApiKey = testSecretApiKey;
+        this.callback = callback;
+    }
+}

--- a/src/main/java/bc1/gream/global/common/ResultCase.java
+++ b/src/main/java/bc1/gream/global/common/ResultCase.java
@@ -61,7 +61,8 @@ public enum ResultCase {
     // 시스템 에러 500
     SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "알 수 없는 에러가 발생했습니다."),
     // 잘못된 도메인 정렬값 입력 400
-    INVALID_ORDER_CRITERIA(HttpStatus.BAD_REQUEST, 5001, "유효하지 않은 도메인 정렬값"),
+    INVALID_ORDER_CRITERIA(HttpStatus.BAD_REQUEST, 5003, "유효하지 않은 도메인 정렬값"),
+    THREAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5004, "유효하지 않은 도메인 정렬값"),
 
     // 쿠폰 6000번대
     // 쿠폰이 존재하지 않을 때 404

--- a/src/main/java/bc1/gream/global/config/AsyncConfig.java
+++ b/src/main/java/bc1/gream/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package bc1.gream.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+}

--- a/src/main/java/bc1/gream/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bc1/gream/global/exception/GlobalExceptionHandler.java
@@ -50,6 +50,17 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Thread 오류 대한 핸들러
+     *
+     * @param ex Thread 오류에 따른 InterruptedException
+     * @return Thread 에러케이스와 에러리스폰스
+     */
+    @ExceptionHandler(InterruptedException.class)
+    public ResponseEntity<RestResponse<ErrorResponseDto>> handlerInterruptedException(InterruptedException ex) {
+        return RestResponse.error(ResultCase.THREAD_ERROR, new ErrorResponseDto());
+    }
+
+    /**
      * Business 오류 발생에 대한 핸들러
      *
      * @param e Business 오류에 따른 GlobalException


### PR DESCRIPTION
## 개요
> **_⚠👨‍💻 꼭 #190 을 확인하고 보시는 걸 추천드립니다,,, #190 의 다음 버전이라고 보시면 됩니다 ⚠👨‍💻_** 
> #190 에서 API 호출 핸들러를 EventPublisher & Callback 을 통해 분리

## 작업사항
![image](https://github.com/Team-BC-1/gream/assets/75259783/223c4936-28b2-4838-a0e3-060d9f43f595)

- [ ] 엔티티
  - [ ] TossPayment 엔티티 구현
  - [ ] PayType 엔티티 구현
  - [ ] OrderName 엔티티 구현
- [ ] 비즈니스 로직
  - [ ] 토스페이 결제에 대한 검증 이후 저장
  - [ ] 토스페이 결제에 대한 성공 리다이렉트
  - [ ] 토스 API 서버 호출
  - [ ] 토스페이 실패 요청 처리
- [ ] application.yml 에 toss api key 추가
- [ ] 이벤트
  - [ ] TossPaymentSuccessEvent 구현
  - [ ] TossPaymentSuccessCallback 구현
  - [ ] TossPaymentEventListener 구현

## Event Publish Process 설명
![image](https://github.com/Team-BC-1/gream/assets/75259783/45004ed3-ece5-40d2-8c65-f5f8fcdfc48e)

- PaymentService 클래스는 결제 관련 작업을 처리
- verifyRequest 메서드는 결제 키, 주문 ID, 금액 등 결제 내역을 확인
- requestFinalTossPayment 메서드는 최종 결제 요청을 시작하고 TossPaymentSuccessEvent를 트리거
- TossPaymentSuccessEvent 이벤트는 게시되어 TossPaymentEventListener로 전파
- TossPaymentEventListener는 TossPaymentSuccessEvent를 수신 대기하고 최종 결제 확인을 전송하는 방식으로 처리


## 관련 이슈
-  close #191 
















