### PR TITLE
Buy 조회기능에 현재시간과 마감기한 비교 필터 추가

### DIFF
--- a/src/main/java/bc1/gream/domain/buy/repository/BuyRepository.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/BuyRepository.java
@@ -1,8 +1,14 @@
 package bc1.gream.domain.buy.repository;
 
 import bc1.gream.domain.buy.entity.Buy;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BuyRepository extends JpaRepository<Buy, Long>, BuyRepositoryCustom {
+
+    @Query("select b from Buy b where b.id = ?1 and b.deadlineAt <= ?2")
+    Optional<Buy> findByIdAndDeadlineAtLessThan(Long id, LocalDateTime deadlineAt);
 
 }

--- a/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustom.java
@@ -4,8 +4,8 @@ import bc1.gream.domain.buy.dto.response.BuyCheckBidResponseDto;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
-import java.time.LocalDateTime;
 import bc1.gream.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,11 +15,11 @@ public interface BuyRepositoryCustom {
 
     Page<Buy> findAllPricesOf(Product product, Pageable pageable);
 
-    Optional<Buy> findByProductIdAndPrice(Long productId, Long price);
+    Optional<Buy> findByProductIdAndPrice(Long productId, Long price, LocalDateTime dateTime);
 
-    Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable);
+    Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable, LocalDateTime dateTime);
 
     void deleteBuysOfDeadlineBefore(LocalDateTime now);
 
-    List<BuyCheckBidResponseDto> findAllBuyBidCoupon(User user);
+    List<BuyCheckBidResponseDto> findAllBuyBidCoupon(User user, LocalDateTime dateTime);
 }

--- a/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImpl.java
@@ -64,32 +64,34 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
     }
 
     /**
-     * 상품 id와 가격에 대해 가장 먼저 생성된 구매입찰 반환
+     * 상품 id와 가격에 대해 마감기한 이전의 가장 먼저 생성된 구매입찰 반환
      *
      * @param productId 상품 id
      * @param price     가격
+     * @param dateTime  주어진 시간
      * @return 가장 먼저 생성된 구매입찰
      */
     @Override
-    public Optional<Buy> findByProductIdAndPrice(Long productId, Long price) {
+    public Optional<Buy> findByProductIdAndPrice(Long productId, Long price, LocalDateTime dateTime) {
         Buy buy = queryFactory
             .selectFrom(QBuy.buy)
             .leftJoin(QBuy.buy.product, product)
-            .where(QBuy.buy.product.id.eq(productId), QBuy.buy.price.eq(price))
+            .where(QBuy.buy.product.id.eq(productId), QBuy.buy.price.eq(price), QBuy.buy.deadlineAt.loe(dateTime))
             .orderBy(QBuy.buy.createdAt.asc())
             .fetchFirst();
         return Optional.ofNullable(buy);
     }
 
     /**
-     * 상품에 대한 구매입찰가격수량에 대한 조건조회,페이징 처리. 기본정렬은 가격 내림차순
+     * 상품에 대한 구매입찰가격수량에 대한 조건조회,페이징 처리. 마감기한 이전의 데이터만 조회. 기본정렬은 가격 내림차순
      *
      * @param product  상품
      * @param pageable 페이징
+     * @param dateTime 주어진 시간
      * @return 구매입찰가격수량
      */
     @Override
-    public Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable) {
+    public Page<BuyPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable, LocalDateTime dateTime) {
         // Get Orders By Columns
         OrderSpecifier[] orderSpecifiers = BuyQueryOrderFactory.getOrdersOf(pageable.getSort());
 
@@ -98,7 +100,7 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
             .select(buy.price, buy.count())
             .from(buy)
             .leftJoin(buy.product, QProduct.product)
-            .where(buy.product.eq(product))
+            .where(buy.product.eq(product), buy.deadlineAt.loe(dateTime))
             .groupBy(buy.price)
             .orderBy(orderSpecifiers)
             .offset(pageable.getOffset())
@@ -131,7 +133,7 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
     }
 
     @Override
-    public List<BuyCheckBidResponseDto> findAllBuyBidCoupon(User user) {
+    public List<BuyCheckBidResponseDto> findAllBuyBidCoupon(User user, LocalDateTime dateTime) {
         return queryFactory.select(
                 buy.id,
                 buy.price,
@@ -145,7 +147,7 @@ public class BuyRepositoryCustomImpl implements BuyRepositoryCustom {
             .leftJoin(buy.product, product)
             .leftJoin(QCoupon.coupon)
             .on(QCoupon.coupon.id.eq(buy.couponId))
-            .where(buy.user.eq(user))
+            .where(buy.user.eq(user), buy.deadlineAt.loe(dateTime))
             .fetch()
             .stream()
             .map(tuple -> BuyCheckBidResponseDto.builder()

--- a/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
+++ b/src/main/java/bc1/gream/domain/buy/service/query/BuyQueryService.java
@@ -13,6 +13,7 @@ import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
 import bc1.gream.domain.product.entity.Product;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,7 +29,7 @@ public class BuyQueryService {
     private final BuyRepository buyRepository;
 
     public Buy findBuyById(Long buyId) {
-        return buyRepository.findById(buyId).orElseThrow(
+        return buyRepository.findByIdAndDeadlineAtLessThan(buyId, LocalDateTime.now()).orElseThrow(
             () -> new GlobalException(BUY_BID_NOT_FOUND)
         );
     }
@@ -41,7 +42,7 @@ public class BuyQueryService {
      * @return 구매입찰가 내역 페이징 데이터
      */
     public Page<BuyPriceToQuantityResponseDto> findAllBuyBidsOf(Product product, Pageable pageable) {
-        return buyRepository.findAllPriceToQuantityOf(product, pageable);
+        return buyRepository.findAllPriceToQuantityOf(product, pageable, LocalDateTime.now());
     }
 
     /**
@@ -52,12 +53,12 @@ public class BuyQueryService {
      * @return 구매입찰
      */
     public Buy getRecentBuyBidOf(Long productId, Long price) {
-        return buyRepository.findByProductIdAndPrice(productId, price)
+        return buyRepository.findByProductIdAndPrice(productId, price, LocalDateTime.now())
             .orElseThrow(() -> new GlobalException(BUY_BID_NOT_FOUND));
     }
 
     public List<BuyCheckBidResponseDto> findAllBuyBidCoupon(User user) {
-        List<BuyCheckBidResponseDto> buyCheckBidResponseDtos = buyRepository.findAllBuyBidCoupon(user);
+        List<BuyCheckBidResponseDto> buyCheckBidResponseDtos = buyRepository.findAllBuyBidCoupon(user, LocalDateTime.now());
 
         return buyCheckBidResponseDtos.stream()
             .map(bid -> BuyMapper.INSTANCE.toBuyCheckBidResponseDto(bid, getFinalPrice(bid.coupon(), bid.discountPrice())))

--- a/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/buy/repository/BuyRepositoryCustomImplTest.java
@@ -9,6 +9,7 @@ import bc1.gream.global.common.ResultCase;
 import bc1.gream.global.exception.GlobalException;
 import bc1.gream.test.BaseDataRepositoryTest;
 import bc1.gream.test.BuyTest;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +59,8 @@ class BuyRepositoryCustomImplTest extends BaseDataRepositoryTest implements BuyT
         Pageable pageable = PageRequest.of(0, 10);
 
         // WHEN
-        Page<BuyPriceToQuantityResponseDto> allPriceToQuantityOf = buyRepositoryCustom.findAllPriceToQuantityOf(savedProduct, pageable);
+        Page<BuyPriceToQuantityResponseDto> allPriceToQuantityOf = buyRepositoryCustom.findAllPriceToQuantityOf(savedProduct, pageable,
+            LocalDateTime.now());
 
         // THEN
         assertEquals(expensiveBuyBid.getPrice(), allPriceToQuantityOf.getContent().get(0).buyPrice());
@@ -101,7 +103,7 @@ class BuyRepositoryCustomImplTest extends BaseDataRepositoryTest implements BuyT
         }
 
         // WHEN
-        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(savedProduct.getId(), TEST_BUY_PRICE)
+        Buy foundBuy = buyRepositoryCustom.findByProductIdAndPrice(savedProduct.getId(), TEST_BUY_PRICE, LocalDateTime.now())
             .orElseThrow(() -> new GlobalException(ResultCase.BUY_BID_NOT_FOUND));
 
         // THEN

--- a/src/test/java/bc1/gream/domain/order/repository/BuyRepositoryTest.java
+++ b/src/test/java/bc1/gream/domain/order/repository/BuyRepositoryTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
-import bc1.gream.domain.product.repository.ProductRepository;
 import bc1.gream.domain.coupon.repository.CouponRepository;
+import bc1.gream.domain.product.repository.ProductRepository;
 import bc1.gream.domain.user.repository.UserRepository;
 import bc1.gream.global.common.ResultCase;
 import bc1.gream.global.config.QueryDslConfig;
@@ -14,6 +14,7 @@ import bc1.gream.global.exception.GlobalException;
 import bc1.gream.global.jpa.AuditingConfig;
 import bc1.gream.test.BuyTest;
 import bc1.gream.test.CouponTest;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -87,7 +88,7 @@ class BuyRepositoryTest implements BuyTest, CouponTest {
         List<Buy> foundBuys = new ArrayList<>();
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
-                Buy buy = buyRepository.findByProductIdAndPrice(TEST_PRODUCT_ID, TEST_BUY_PRICE)
+                Buy buy = buyRepository.findByProductIdAndPrice(TEST_PRODUCT_ID, TEST_BUY_PRICE, LocalDateTime.now())
                     .orElseThrow(() -> new GlobalException(ResultCase.BUY_BID_NOT_FOUND));
                 foundBuys.add(buy);
 //                try{


### PR DESCRIPTION
## 개요
> 스케줄러가 안 도는 경우를 대비하여 Buy 조회기능에 현재시간, 마감기한 비교 필터를 추가하였습니다.

## 작업사항
-  현재시간 입력하여, 마감기한이 이후 시간인지 필터링
- QueryDsl 에 loe절을 사용하여 현재시간과 마감기한 비교

## 관련 이슈
- close #239 
