### PR TITLE
구매 입찰 취소 기능 테스트 추가

### DIFF
--- a/src/test/java/bc1/gream/domain/buy/controller/BuyBidControllerTest.java
+++ b/src/test/java/bc1/gream/domain/buy/controller/BuyBidControllerTest.java
@@ -2,6 +2,7 @@ package bc1.gream.domain.buy.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bc1.gream.domain.buy.dto.request.BuyBidRequestDto;
 import bc1.gream.domain.buy.dto.response.BuyBidResponseDto;
+import bc1.gream.domain.buy.dto.response.BuyCancelBidResponseDto;
 import bc1.gream.domain.buy.provider.BuyBidProvider;
 import bc1.gream.domain.order.validator.ProductValidator;
 import bc1.gream.domain.product.entity.Product;
@@ -84,6 +86,22 @@ class BuyBidControllerTest implements UserTest, ProductTest {
     }
 
     @Test
-    void buyCancelBid() {
+    @DisplayName("구매 입찰 컨트롤러 기능 중 구매 입찰을 취소하는 기능 성공 테스트")
+    void 구매_입찰취소_성공_테스트() throws Exception {
+        // given
+        Long buyId = 1L;
+        BuyCancelBidResponseDto responseDto = BuyCancelBidResponseDto.builder()
+            .buyId(buyId)
+            .build();
+
+        given(buyBidProvider.buyCancelBid(any(User.class), any(Long.class))).willReturn(responseDto);
+        // when - then
+        mockMvc.perform(delete("/api/buy/bid/{buyId}", buyId))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.code").value(0),
+                jsonPath("$.message").value("정상 처리 되었습니다"),
+                jsonPath("$.data.buyId").value(buyId)
+            );
     }
 }

--- a/src/test/java/bc1/gream/domain/buy/provider/BuyBidProviderTest.java
+++ b/src/test/java/bc1/gream/domain/buy/provider/BuyBidProviderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import bc1.gream.domain.buy.dto.request.BuyBidRequestDto;
 import bc1.gream.domain.buy.dto.response.BuyBidResponseDto;
+import bc1.gream.domain.buy.dto.response.BuyCancelBidResponseDto;
 import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
 import bc1.gream.domain.buy.service.command.BuyCommandService;
@@ -86,4 +87,33 @@ class BuyBidProviderTest implements CouponTest, UserTest, ProductTest, BuyTest {
         assertThat(responseDto.price()).isEqualTo(TEST_BUY_PRICE);
     }
 
+    @Test
+    void 구매_입찰취소_쿠폰_없을때_Provider_성공_테스트() {
+
+        // given
+        given(buyQueryService.findBuyById(any(Long.class))).willReturn(TEST_BUY);
+
+        // when
+        BuyCancelBidResponseDto responseDto = buyBidProvider.buyCancelBid(TEST_USER, 1L);
+
+        // then
+        assertThat(responseDto.buyId()).isEqualTo(1L);
+        verify(buyCommandService, times(1)).deleteBuyByIdAndUser(any(Buy.class), any(User.class));
+    }
+
+    @Test
+    void 구매_입찰취소_쿠폰_있을때_Provider_성공_테스트() {
+
+        // given
+        given(buyQueryService.findBuyById(any(Long.class))).willReturn(TEST_BUY_COUPON);
+        given(couponQueryService.checkCoupon(any(Long.class), any(User.class), any(CouponStatus.class))).willReturn(TEST_COUPON_FIX);
+
+        // when
+        BuyCancelBidResponseDto responseDto = buyBidProvider.buyCancelBid(TEST_USER, 1L);
+
+        // then
+        assertThat(responseDto.buyId()).isEqualTo(1L);
+        verify(buyCommandService, times(1)).deleteBuyByIdAndUser(any(Buy.class), any(User.class));
+        verify(couponCommandService, times(1)).changeCouponStatus(any(Coupon.class), any(CouponStatus.class));
+    }
 }

--- a/src/test/java/bc1/gream/domain/buy/service/command/BuyCommandServiceTest.java
+++ b/src/test/java/bc1/gream/domain/buy/service/command/BuyCommandServiceTest.java
@@ -1,0 +1,74 @@
+package bc1.gream.domain.buy.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import bc1.gream.domain.buy.entity.Buy;
+import bc1.gream.domain.buy.repository.BuyRepository;
+import bc1.gream.global.common.ResultCase;
+import bc1.gream.global.exception.GlobalException;
+import bc1.gream.test.BuyTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BuyCommandServiceTest implements BuyTest {
+
+    @InjectMocks
+    private BuyCommandService buyCommandService;
+
+    @Mock
+    private BuyRepository buyRepository;
+
+    @Test
+    void 구매_아이디와_유저로_구매입찰_취소하는_서비스_기능_성공_테스트() {
+
+        // given - when
+        buyCommandService.deleteBuyByIdAndUser(TEST_BUY, TEST_USER);
+
+        // then
+        verify(buyRepository, times(1)).delete(any(Buy.class));
+    }
+
+    @Test
+    void 구매_아이디와_유저로_구매입찰_취소하는_서비스_기능_실패_테스트() {
+
+        // given - when
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            buyCommandService.deleteBuyByIdAndUser(TEST_BUY, TEST_BUYER);
+        });
+
+        // then
+        assertThat(exception.getResultCase()).isEqualTo(ResultCase.NOT_AUTHORIZED);
+        assertThat(exception.getResultCase().getCode()).isEqualTo(5000);
+        assertThat(exception.getResultCase().getMessage()).isEqualTo("해당 요청에 대한 권한이 없습니다.");
+    }
+
+
+    @Test
+    void 구매입찰_취소하는_서비스_기능_성공_테스트() {
+
+        // given - when
+        buyCommandService.delete(TEST_BUY);
+
+        // then
+        verify(buyRepository, times(1)).delete(any(Buy.class));
+    }
+
+    @Test
+    void 구매자가_정한_기한이_지난_구매입찰_삭제_서비스_성공_테스트() {
+
+        // given - when
+        buyCommandService.deleteBuysOfDeadlineBefore(TEST_DEADLINE_AT);
+
+        // then
+        verify(buyRepository, times(1)).deleteBuysOfDeadlineBefore(any(LocalDateTime.class));
+    }
+}

--- a/src/test/java/bc1/gream/domain/buy/service/query/BuyQueryServiceTest.java
+++ b/src/test/java/bc1/gream/domain/buy/service/query/BuyQueryServiceTest.java
@@ -2,20 +2,36 @@ package bc1.gream.domain.buy.service.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
+import bc1.gream.domain.buy.dto.response.BuyCheckBidResponseDto;
+import bc1.gream.domain.buy.entity.Buy;
 import bc1.gream.domain.buy.repository.BuyRepository;
+import bc1.gream.domain.coupon.helper.CouponCalculator;
+import bc1.gream.domain.product.dto.response.BuyPriceToQuantityResponseDto;
+import bc1.gream.domain.product.entity.Product;
+import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.common.ResultCase;
 import bc1.gream.global.exception.GlobalException;
-import bc1.gream.test.UserTest;
+import bc1.gream.test.BuyTest;
+import bc1.gream.test.CouponTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-class BuyQueryServiceTest implements UserTest {
+class BuyQueryServiceTest implements BuyTest, CouponTest {
 
     @InjectMocks
     private BuyQueryService buyQueryService;
@@ -23,23 +39,136 @@ class BuyQueryServiceTest implements UserTest {
     private BuyRepository buyRepository;
 
     @Test
-    void findBuyById() {
+    void 구매_아이디로_구매입찰_찾아오는_서비스_기능_성공_테스트() {
+
+        // given
+        given(buyRepository.findById(any(Long.class))).willReturn(Optional.of(TEST_BUY));
+
+        // when
+        Buy buy = buyQueryService.findBuyById(any(Long.class));
+
+        // then
+        assertThat(buy.getPrice()).isEqualTo(TEST_BUY_PRICE);
+        assertThat(buy.getUser()).isEqualTo(TEST_USER);
+        assertThat(buy.getProduct()).isEqualTo(TEST_PRODUCT);
     }
 
     @Test
-    void findAllBuyBidsOf() {
+    void 구매_아이디로_구매입찰_찾아오는_서비스_기능_실패_테스트() {
+
+        // given
+        given(buyRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            buyQueryService.findBuyById(any(Long.class));
+        });
+
+        // then
+        assertThat(exception.getResultCase()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND);
+        assertThat(exception.getResultCase().getCode()).isEqualTo(3001);
+        assertThat(exception.getResultCase().getMessage()).isEqualTo("해당 구매 입찰 건은 존재하지 않습니다.");
     }
 
     @Test
-    void getRecentBuyBidOf() {
+    void 특정_상품의_구매입찰_중_같은_가격의_개수를_모두_카운트하고_페이징하여_출력하는_서비스_기능_성공_테스트() {
+
+        // given
+        Pageable pageable = PageRequest.of(0, 5);
+
+        List<BuyPriceToQuantityResponseDto> responseDtoList = new ArrayList<>();
+
+        for (int i = 1; i <= 5; i++) {
+            BuyPriceToQuantityResponseDto responseDto = BuyPriceToQuantityResponseDto.builder()
+                .buyPrice(1000L * i)
+                .quantity((long) i)
+                .build();
+            responseDtoList.add(responseDto);
+        }
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), responseDtoList.size());
+        Page<BuyPriceToQuantityResponseDto> responseDtoPage = new PageImpl<>(responseDtoList.subList(start, end), pageable,
+            responseDtoList.size());
+
+        given(buyRepository.findAllPriceToQuantityOf(any(Product.class), any(Pageable.class))).willReturn(responseDtoPage);
+        // when
+        Page<BuyPriceToQuantityResponseDto> returnPage = buyQueryService.findAllBuyBidsOf(TEST_PRODUCT, pageable);
+
+        // then
+        assertThat(returnPage.getSize()).isEqualTo(5);
+        assertThat(returnPage.getContent().get(0).buyPrice()).isEqualTo(1000L);
+        assertThat(returnPage.getContent().get(1).buyPrice()).isEqualTo(2000L);
+        assertThat(returnPage.getContent().get(2).buyPrice()).isEqualTo(3000L);
+        assertThat(returnPage.getContent().get(3).buyPrice()).isEqualTo(4000L);
+        assertThat(returnPage.getContent().get(4).buyPrice()).isEqualTo(5000L);
     }
 
     @Test
-    void findAllBuyBidCoupon() {
+    void 가장_최근의_구매입찰을_찾아오는_서비스_기능_성공_테스트() {
+
+        // given
+        given(buyRepository.findByProductIdAndPrice(any(Long.class), any(Long.class))).willReturn(Optional.of(TEST_BUY));
+
+        // when
+        Buy resultBuy = buyQueryService.getRecentBuyBidOf(TEST_PRODUCT_ID, TEST_BUY_PRICE);
+
+        // then
+        assertThat(resultBuy.getPrice()).isEqualTo(TEST_BUY.getPrice());
+        assertThat(resultBuy.getProduct()).isEqualTo(TEST_BUY.getProduct());
+        assertThat(resultBuy.getUser()).isEqualTo(TEST_BUY.getUser());
     }
 
     @Test
-    void 유저의_포인트_체크하는_기능_성공_테스트() {
+    void 가장_최근의_구매입찰을_찾아오는_서비스_기능_실패_테스트() {
+
+        // given
+        given(buyRepository.findByProductIdAndPrice(any(Long.class), any(Long.class))).willReturn(Optional.empty());
+
+        // when
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
+            buyQueryService.getRecentBuyBidOf(TEST_PRODUCT_ID, TEST_BUY_PRICE);
+        });
+
+        // then
+        assertThat(exception.getResultCase()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND);
+        assertThat(exception.getResultCase().getMessage()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND.getMessage());
+        assertThat(exception.getResultCase().getCode()).isEqualTo(ResultCase.BUY_BID_NOT_FOUND.getCode());
+    }
+
+    @Test
+    void 현재_진행중인_유저의_구매입찰_전체_조회_서비스_기능_성공_테스트() {
+
+        // given
+        List<BuyCheckBidResponseDto> responseDtoList = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            BuyCheckBidResponseDto responseDto = BuyCheckBidResponseDto.builder()
+                .buyId((long) i)
+                .price(1000L * i)
+                .discountPrice(1000L * i)
+                .coupon((i % 2 == 0) ? TEST_COUPON_FIX : null)
+                .build();
+
+            responseDtoList.add(responseDto);
+        }
+        given(buyRepository.findAllBuyBidCoupon(any(User.class))).willReturn(responseDtoList);
+
+        // when
+        List<BuyCheckBidResponseDto> resultList = buyQueryService.findAllBuyBidCoupon(TEST_USER);
+
+        // then
+        assertThat(resultList.size()).isEqualTo(5);
+        assertThat(resultList.get(0).discountPrice()).isEqualTo(responseDtoList.get(0).discountPrice());
+        assertThat(resultList.get(1).discountPrice()).isEqualTo(
+            CouponCalculator.calculateDiscount(TEST_COUPON_FIX, responseDtoList.get(1).discountPrice()));
+        assertThat(resultList.get(2).discountPrice()).isEqualTo(responseDtoList.get(2).discountPrice());
+        assertThat(resultList.get(3).discountPrice()).isEqualTo(
+            CouponCalculator.calculateDiscount(TEST_COUPON_FIX, responseDtoList.get(3).discountPrice()));
+        assertThat(resultList.get(4).discountPrice()).isEqualTo(responseDtoList.get(4).discountPrice());
+    }
+
+    @Test
+    void 유저의_포인트_체크하는_서비스_기능_성공_테스트() {
 
         // given
         ReflectionTestUtils.setField(TEST_USER, "point", 10000L);
@@ -49,7 +178,7 @@ class BuyQueryServiceTest implements UserTest {
     }
 
     @Test
-    void 유저의_포인트_체크하는_기능_실패_테스트() {
+    void 유저의_포인트_체크하는_서비스_기능_실패_테스트() {
 
         // given
         ReflectionTestUtils.setField(TEST_USER, "point", 3000L);

--- a/src/test/java/bc1/gream/test/BuyTest.java
+++ b/src/test/java/bc1/gream/test/BuyTest.java
@@ -17,4 +17,12 @@ public interface BuyTest extends UserTest, ProductTest {
         .user(TEST_USER)
         .product(TEST_PRODUCT)
         .build();
+
+    Buy TEST_BUY_COUPON = Buy.builder()
+        .price(TEST_BUY_PRICE)
+        .deadlineAt(TEST_DEADLINE_AT)
+        .user(TEST_USER)
+        .product(TEST_PRODUCT)
+        .couponId(1L)
+        .build();
 }


### PR DESCRIPTION
## 개요
구매 입찰 취소 기능 테스트 추가

## 작업사항
- 구매 입찰 취소 컨트롤러 테스트 추가
- 구매 입찰 취소 provider 테스트 추가
- 구매 Query Service 테스트 추가
- 구매 Command Service 테스트 추가

## 관련 이슈
-  close #240 
