### PR TITLE
Sell 조회 시, 마감기한 이전의 데이터만을 조회

### DIFF
--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepository.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepository.java
@@ -2,6 +2,7 @@ package bc1.gream.domain.sell.repository;
 
 import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.user.entity.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +11,5 @@ public interface SellRepository extends JpaRepository<Sell, Long>, SellRepositor
 
     Optional<Sell> findByIdAndUser(Long sellId, User user);
 
-    List<Sell> findAllByUser(User seller);
+    List<Sell> findAllByUserAndDeadlineAtGreaterThan(User seller, LocalDateTime localDateTime);
 }

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface SellRepositoryCustom {
 
     Page<Sell> findAllPricesOf(Product product, Pageable pageable);
 
-    Optional<Sell> findByProductIdAndPrice(Long productId, Long price);
+    Optional<Sell> findByProductIdAndPrice(Long productId, Long price, LocalDateTime localDateTime);
 
     Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable, LocalDateTime localDateTime);
 

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustom.java
@@ -14,7 +14,7 @@ public interface SellRepositoryCustom {
 
     Optional<Sell> findByProductIdAndPrice(Long productId, Long price);
 
-    Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable);
+    Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable, LocalDateTime localDateTime);
 
     void deleteSellsOfDeadlineBefore(LocalDateTime dateTime);
 }

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
@@ -61,19 +61,20 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
     }
 
     /**
-     * 상품 id와 가격에 대해 가장 나중에 생성된 판매입찰 반환
+     * 상품 id와 가격에 대해 가장 나중에 생성된 판매입찰 반환. 마감기한이 현재시간 이후인지 확인
      *
-     * @param productId 상품 id
-     * @param price     가격
+     * @param productId     상품 id
+     * @param price         가격
+     * @param localDateTime 현재시간
      * @return 가장 나중에 생성된 판매입찰 반환
      */
     @Override
-    public Optional<Sell> findByProductIdAndPrice(Long productId, Long price) {
+    public Optional<Sell> findByProductIdAndPrice(Long productId, Long price, LocalDateTime localDateTime) {
         Sell foundSell = queryFactory.selectFrom(sell)
             .leftJoin(sell.product, product)
             .leftJoin(sell.gifticon, gifticon)
             .leftJoin(sell.user, user)
-            .where(sell.product.id.eq(productId), sell.price.eq(price))
+            .where(sell.product.id.eq(productId), sell.price.eq(price), sell.deadlineAt.gt(localDateTime))
             .orderBy(sell.createdAt.asc())
             .fetchFirst();
         return Optional.ofNullable(foundSell);

--- a/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
+++ b/src/main/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImpl.java
@@ -80,14 +80,15 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
     }
 
     /**
-     * 상품에 대한 판매입찰가격수량에 대한 조건조회,페이징 처리. 기본정렬은 가격 오름차순
+     * 상품에 대한 판매입찰가격수량에 대한 조건조회,페이징 처리. 마감기한이 현재시간 이후인지 확인. 기본정렬은 가격 오름차순
      *
-     * @param product  상품
-     * @param pageable 페이징
+     * @param product       상품
+     * @param pageable      페이징
+     * @param localDateTime 현재시간
      * @return 판매입찰가격수량
      */
     @Override
-    public Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable) {
+    public Page<SellPriceToQuantityResponseDto> findAllPriceToQuantityOf(Product product, Pageable pageable, LocalDateTime localDateTime) {
         // Get Orders By Columns
         OrderSpecifier[] orderSpecifiers = SellQueryOrderFactory.getOrdersOf(pageable.getSort());
 
@@ -96,7 +97,7 @@ public class SellRepositoryCustomImpl implements SellRepositoryCustom {
             .select(sell.price, sell.count())
             .from(sell)
             .leftJoin(sell.product, QProduct.product)
-            .where(sell.product.eq(product))
+            .where(sell.product.eq(product), sell.deadlineAt.gt(localDateTime))
             .groupBy(sell.price)
             .orderBy(orderSpecifiers)
             .fetch()

--- a/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
@@ -8,6 +8,7 @@ import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.domain.sell.repository.SellRepository;
 import bc1.gream.domain.user.entity.User;
 import bc1.gream.global.exception.GlobalException;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,7 +32,7 @@ public class SellQueryService {
      */
     @Transactional(readOnly = true)
     public Page<SellPriceToQuantityResponseDto> findAllSellBidsOf(Product product, Pageable pageable) {
-        return sellRepository.findAllPriceToQuantityOf(product, pageable);
+        return sellRepository.findAllPriceToQuantityOf(product, pageable, LocalDateTime.now());
     }
 
 

--- a/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
@@ -50,7 +50,13 @@ public class SellQueryService {
         );
     }
 
+    /**
+     * 진행 중인 판매자의 판매입찰 내역 조회
+     *
+     * @param seller 판매자
+     * @return 마감기한 이전의 진행 중인 판매입찰 리스트
+     */
     public List<Sell> getUserSellOnProgressOf(User seller) {
-        return sellRepository.findAllByUser(seller);
+        return sellRepository.findAllByUserAndDeadlineAtGreaterThan(seller, LocalDateTime.now());
     }
 }

--- a/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
+++ b/src/main/java/bc1/gream/domain/sell/service/query/SellQueryService.java
@@ -45,7 +45,7 @@ public class SellQueryService {
 
     @Transactional(readOnly = true)
     public Sell getRecentSellBidof(Long productId, Long price) {
-        return sellRepository.findByProductIdAndPrice(productId, price).orElseThrow(
+        return sellRepository.findByProductIdAndPrice(productId, price, LocalDateTime.now()).orElseThrow(
             () -> new GlobalException(SELL_BID_PRODUCT_NOT_FOUND)
         );
     }

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryCustomImplTest.java
@@ -11,6 +11,7 @@ import bc1.gream.domain.sell.entity.Sell;
 import bc1.gream.test.BaseDataRepositoryTest;
 import bc1.gream.test.SellTest;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
@@ -130,7 +131,8 @@ class SellRepositoryCustomImplTest extends BaseDataRepositoryTest implements Sel
         Pageable pageable = PageRequest.of(1, 10);
 
         // WHEN
-        Page<SellPriceToQuantityResponseDto> allPriceToQuantityOf = sellRepositoryCustom.findAllPriceToQuantityOf(savedProduct, pageable);
+        Page<SellPriceToQuantityResponseDto> allPriceToQuantityOf = sellRepositoryCustom.findAllPriceToQuantityOf(savedProduct, pageable,
+            LocalDateTime.now());
 
         // THEN
         assertEquals(samePriceBid.getPrice(), allPriceToQuantityOf.getContent().get(0).sellPrice());

--- a/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryTest.java
+++ b/src/test/java/bc1/gream/domain/sell/repository/SellRepositoryTest.java
@@ -14,6 +14,7 @@ import bc1.gream.global.config.QueryDslConfig;
 import bc1.gream.global.exception.GlobalException;
 import bc1.gream.global.jpa.AuditingConfig;
 import bc1.gream.test.SellTest;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,7 +86,7 @@ class SellRepositoryTest implements SellTest {
         }
 
         // WHEN
-        Sell foundSell = sellRepository.findByProductIdAndPrice(savedProduct.getId(), TEST_SELL_PRICE)
+        Sell foundSell = sellRepository.findByProductIdAndPrice(savedProduct.getId(), TEST_SELL_PRICE, LocalDateTime.now())
             .orElseThrow(() -> new GlobalException(ResultCase.SELL_BID_PRODUCT_NOT_FOUND));
 
         // THEN


### PR DESCRIPTION
## 개요
> AWS Lambda 의 스케줄러 처리가 안 되는 경우를 대비하여, 마감기한이 현재시간 이후인지에 대한 WHERE절을 추가하였습니다.

## 작업사항
- "Product에 대한 판매입찰가 내역 페이징 조회" 기능에 마감기한이 현재시간 이후인지에 대한 WHERE 절 추가

- "해당상품과 가격에 대한 판매입찰 조회" 기능에 마감기한이 현재시간 이후인지에 대한 WHERE 절 추가

- "진행 중인 판매자의 판매입찰 내역 조회" 기능에 마감기한이 현재시간 이후인지에 대한 WHERE 절 추가

## 관련 이슈
- close #248 
